### PR TITLE
Fix CVAT format import for frame stepped tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed multiple errors which arises when polygon is of length 5 or less (<https://github.com/opencv/cvat/pull/2100>)
+- Fixed CVAT format import for frame stepped tasks (<https://github.com/openvinotoolkit/cvat/pull/2151>)
 
 ### Security
 -

--- a/cvat/apps/dataset_manager/formats/cvat.py
+++ b/cvat/apps/dataset_manager/formats/cvat.py
@@ -442,7 +442,9 @@ def load(file_object, annotations):
                 )
             elif el.tag == 'image':
                 image_is_opened = True
-                frame_id = match_dm_item(DatasetItem(id=el.attrib['id'], image=el.attrib['name']), annotations)
+                frame_id = annotations.abs_frame_id(match_dm_item(
+                    DatasetItem(id=el.attrib['id'], image=el.attrib['name']),
+                    annotations))
             elif el.tag in supported_shapes and (track is not None or image_is_opened):
                 attributes = []
                 shape = {

--- a/cvat/apps/engine/tests/_test_rest_api.py
+++ b/cvat/apps/engine/tests/_test_rest_api.py
@@ -2082,7 +2082,14 @@ class JobAnnotationAPITestCase(APITestCase):
                 "client_files[0]": generate_image_file("test_1.jpg")[1],
                 "client_files[1]": generate_image_file("test_2.jpg")[1],
                 "client_files[2]": generate_image_file("test_3.jpg")[1],
+                "client_files[4]": generate_image_file("test_4.jpg")[1],
+                "client_files[5]": generate_image_file("test_5.jpg")[1],
+                "client_files[6]": generate_image_file("test_6.jpg")[1],
+                "client_files[7]": generate_image_file("test_7.jpg")[1],
+                "client_files[8]": generate_image_file("test_8.jpg")[1],
+                "client_files[9]": generate_image_file("test_9.jpg")[1],
                 "image_quality": 75,
+                "frame_filter": "step=3",
             }
             response = self.client.post("/api/v1/tasks/{}/data".format(tid), data=images)
             assert response.status_code == status.HTTP_202_ACCEPTED
@@ -2202,7 +2209,7 @@ class JobAnnotationAPITestCase(APITestCase):
                     "occluded": False
                 },
                 {
-                    "frame": 1,
+                    "frame": 2,
                     "label_id": task["labels"][1]["id"],
                     "group": None,
                     "source": "manual",
@@ -2239,7 +2246,7 @@ class JobAnnotationAPITestCase(APITestCase):
                             ]
                         },
                         {
-                            "frame": 1,
+                            "frame": 2,
                             "attributes": [],
                             "points": [2.0, 2.1, 100, 300.222],
                             "type": "rectangle",
@@ -2256,7 +2263,7 @@ class JobAnnotationAPITestCase(APITestCase):
                     "attributes": [],
                     "shapes": [
                         {
-                            "frame": 1,
+                            "frame": 2,
                             "attributes": [],
                             "points": [1.0, 2.1, 100, 300.222],
                             "type": "rectangle",


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

After #1807 there was a problem: after a frame is matched, a relative id is obtained. This relative id is then used for annotations where absolute id is expected. A relative id = absolute id / step.

Affected releases: 1.1.0-beta, 1.1.0

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Unit tests

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [x] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
