### PR TITLE
Cypress test to check registration, change password, login

### DIFF
--- a/tests/cypress.json
+++ b/tests/cypress.json
@@ -11,6 +11,7 @@
     "testFiles": [
         "auth_page.js",
         "issue_*.js",
+        "case_*.js",
         "remove_users_tasks.js"
     ]
 }

--- a/tests/cypress/integration/case_2_register_user_change_pass.js
+++ b/tests/cypress/integration/case_2_register_user_change_pass.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/// <reference types="cypress" />
+
+context('Register user, change password, login with new password', () => {
+    const caseId = '2'
+    const firstName = 'First name'
+    const lastName = 'Last name'
+    const userName = 'Username'
+    const emailAddr = `${userName}@local.local`
+    const password = 'UfdU21!dds'
+    const newPassword = 'dKl3j49sd@jjk'
+
+    before(() => {
+        cy.visit('auth/register')
+        cy.url().should('include', '/auth/register')
+    })
+
+    describe(`Testing "Case ${caseId}"`, () => {
+        it('Register user, change password', () => {
+            cy.userRegistration(firstName, lastName, userName, emailAddr, password)
+            cy.url().should('include', '/tasks')
+            cy.get('.cvat-right-header')
+            .find('.cvat-header-menu-dropdown')
+            .should('have.text', userName)
+            .trigger('mouseover')
+            cy.get('.anticon-edit')
+            .click()
+            cy.get('.ant-modal-body').within(() => {
+                cy.get('#oldPassword').type(password)
+                cy.get('#newPassword1').type(newPassword)
+                cy.get('#newPassword2').type(newPassword)
+                cy.get('.change-password-form-button').click()
+            })
+            cy.contains('New password has been saved.')
+            .should('exist')
+        })
+        it('Logout', () => {
+            cy.logout(userName)
+            cy.url().should('include', '/auth/login')
+        })
+        it('Login with the new password', () => {
+            cy.login(userName, newPassword)
+            cy.url().should('include', '/tasks')
+        })
+    })
+})

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -25,6 +25,16 @@ Cypress.Commands.add('logout', (username=Cypress.env('user')) => {
     .click()
 })
 
+Cypress.Commands.add('userRegistration', (firstName, lastName, userName, emailAddr, password) => {
+    cy.get('#firstName').type(firstName)
+    cy.get('#lastName').type(lastName)
+    cy.get('#username').type(userName)
+    cy.get('#email').type(emailAddr)
+    cy.get('#password1').type(password)
+    cy.get('#password2').type(password)
+    cy.get('.register-form-button').click()
+})
+
 Cypress.Commands.add('createAnnotationTask', (taksName='New annotation task',
                                               labelName='Some label',
                                               attrName='Some attr name',


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

Cypress test to check:
- User registration
- Change user password
- Login with the new password

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
