### PR TITLE
Cypress test to check task parameters frame

### DIFF
--- a/tests/cypress/integration/case_3_task_start_stop_step_frame.js
+++ b/tests/cypress/integration/case_3_task_start_stop_step_frame.js
@@ -14,25 +14,27 @@ context('Check if parameters "startFrame", "stopFrame", "frameStep" works as exp
     const attrName = `Attr for ${labelName}`
     const textDefaultValue = 'Some default value for type Text'
     const imagesCount = 10
+    const imageFileName = `image_${labelName.replace(' ', '_').toLowerCase()}`
     let images = []
     for ( let i = 1; i <= imagesCount; i++) {
-        images.push(`image_${labelName.replace(' ', '_').toLowerCase()}_${i}.png`)
+        images.push(`${imageFileName}_${i}.png`)
     }
     const width = 800
     const height = 800
     const posX = 10
     const posY = 10
     const color = 'gray'
-    const archiveName = `images_${labelName.replace(' ', '_').toLowerCase()}.zip`
+    const archiveName = `${imageFileName}.zip`
     const archivePath = `cypress/fixtures/${archiveName}`
-    const imagesFolder = `cypress/fixtures/image_${labelName.replace(' ', '_').toLowerCase()}`
+    const imagesFolder = `cypress/fixtures/${imageFileName}`
     const directoryToArchive = imagesFolder
-    const advancedConfiguration = true
-    const multiJobs = false
-    const sssFrame = true
-    const startFrame = 2
-    const stopFrame = 8
-    const frameStep = 2
+    const advancedConfigurationParams = {
+        multiJobs: false,
+        sssFrame: true,
+        startFrame: 2,
+        stopFrame: 8,
+        frameStep: 2
+    }
 
     before(() => {
         cy.visit('auth/login')
@@ -46,12 +48,12 @@ context('Check if parameters "startFrame", "stopFrame", "frameStep" works as exp
     describe(`Testing "${labelName}"`, () => {
         it('Create a task. Open the task.', () => {
             cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, archiveName,
-                false, '', '', '', advancedConfiguration, multiJobs, '', sssFrame, startFrame, stopFrame, frameStep)
+                null, advancedConfigurationParams)
             cy.openTaskJob(taskName)
         })
         it('Parameters "startFrame", "stopFrame", "frameStep" works as expected ', () => {
             cy.get('.cvat-player-filename-wrapper')
-            .should('contain', `image_${labelName.replace(' ', '_').toLowerCase()}_${startFrame}.png`)
+            .should('contain', `${imageFileName}_${advancedConfigurationParams.startFrame}.png`)
             cy.get('.cvat-player-frame-selector').within(() => {
                 cy.get('input[role="spinbutton"]')
                 .should('have.value', '0')
@@ -59,7 +61,7 @@ context('Check if parameters "startFrame", "stopFrame", "frameStep" works as exp
             cy.get('.cvat-player-next-button')
             .click()
             cy.get('.cvat-player-filename-wrapper')
-            .should('contain', `image_${labelName.replace(' ', '_').toLowerCase()}_${startFrame + frameStep}.png`)
+            .should('contain', `${imageFileName}_${advancedConfigurationParams.startFrame + advancedConfigurationParams.frameStep}.png`)
             cy.get('.cvat-player-frame-selector').within(() => {
                 cy.get('input[role="spinbutton"]')
                 .should('have.value', '1')
@@ -67,7 +69,7 @@ context('Check if parameters "startFrame", "stopFrame", "frameStep" works as exp
             cy.get('.cvat-player-last-button')
             .click()
             cy.get('.cvat-player-filename-wrapper')
-            .should('contain', `image_${labelName.replace(' ', '_').toLowerCase()}_${stopFrame}.png`)
+            .should('contain', `${imageFileName}_${advancedConfigurationParams.stopFrame}.png`)
             cy.get('.cvat-player-frame-selector').within(() => {
                 cy.get('input[role="spinbutton"]')
                 .should('have.value', '3')

--- a/tests/cypress/integration/case_3_task_start_stop_step_frame.js
+++ b/tests/cypress/integration/case_3_task_start_stop_step_frame.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/// <reference types="cypress" />
+
+context('Check if parameters "startFrame", "stopFrame", "frameStep" works as expected', () => {
+
+    const caseId = '3'
+    const labelName = `Case ${caseId}`
+    const taskName = `New annotation task for ${labelName}`
+    const attrName = `Attr for ${labelName}`
+    const textDefaultValue = 'Some default value for type Text'
+    const imagesCount = 10
+    let images = []
+    for ( let i = 1; i <= imagesCount; i++) {
+        images.push(`image_${labelName.replace(' ', '_').toLowerCase()}_${i}.png`)
+    }
+    const width = 800
+    const height = 800
+    const posX = 10
+    const posY = 10
+    const color = 'gray'
+    const archiveName = `images_${labelName.replace(' ', '_').toLowerCase()}.zip`
+    const archivePath = `cypress/fixtures/${archiveName}`
+    const imagesFolder = `cypress/fixtures/image_${labelName.replace(' ', '_').toLowerCase()}`
+    const directoryToArchive = imagesFolder
+    const advancedConfiguration = true
+    const multiJobs = false
+    const sssFrame = true
+    const startFrame = 2
+    const stopFrame = 8
+    const frameStep = 2
+
+    before(() => {
+        cy.visit('auth/login')
+        cy.login()
+        for (let img of images) {
+            cy.imageGenerator(imagesFolder, img, width, height, color, posX, posY, labelName)
+        }
+        cy.createZipArchive(directoryToArchive, archivePath)
+    })
+
+    describe(`Testing "${labelName}"`, () => {
+        it('Create a task. Open the task.', () => {
+            cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, archiveName,
+                false, '', '', '', advancedConfiguration, multiJobs, '', sssFrame, startFrame, stopFrame, frameStep)
+            cy.openTaskJob(taskName)
+        })
+        it('Parameters "startFrame", "stopFrame", "frameStep" works as expected ', () => {
+            cy.get('.cvat-player-filename-wrapper')
+            .should('contain', `image_${labelName.replace(' ', '_').toLowerCase()}_${startFrame}.png`)
+            cy.get('.cvat-player-frame-selector').within(() => {
+                cy.get('input[role="spinbutton"]')
+                .should('have.value', '0')
+            })
+            cy.get('.cvat-player-next-button')
+            .click()
+            cy.get('.cvat-player-filename-wrapper')
+            .should('contain', `image_${labelName.replace(' ', '_').toLowerCase()}_${startFrame + frameStep}.png`)
+            cy.get('.cvat-player-frame-selector').within(() => {
+                cy.get('input[role="spinbutton"]')
+                .should('have.value', '1')
+            })
+            cy.get('.cvat-player-last-button')
+            .click()
+            cy.get('.cvat-player-filename-wrapper')
+            .should('contain', `image_${labelName.replace(' ', '_').toLowerCase()}_${stopFrame}.png`)
+            cy.get('.cvat-player-frame-selector').within(() => {
+                cy.get('input[role="spinbutton"]')
+                .should('have.value', '3')
+            })
+        })
+    })
+})

--- a/tests/cypress/integration/issue_1425_highlighted_attribute_correspond_chosen_attribute.js
+++ b/tests/cypress/integration/issue_1425_highlighted_attribute_correspond_chosen_attribute.js
@@ -19,9 +19,11 @@ context('The highlighted attribute in AAM should correspond to the chosen attrib
     const posX = 10
     const posY = 10
     const color = 'gray'
-    const additionalAttrName = `Attr 2`
-    const additionalValue = `Attr value 2`
-    const typeAttribute = 'Text'
+    const multiAttrParams = {
+        additionalAttrName: `Attr 2`,
+        additionalValue: `Attr value 2`,
+        typeAttribute: 'Text'
+    }
     let textValue = ''
 
     before(() => {
@@ -32,7 +34,7 @@ context('The highlighted attribute in AAM should correspond to the chosen attrib
 
     describe(`Testing issue "${issueId}"`, () => {
         it('Create a task with multiple attributes, create a object', () => {
-            cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, image, false, 1, true, additionalAttrName, typeAttribute, additionalValue)
+            cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, image, multiAttrParams)
             cy.openTaskJob(taskName)
             cy.createShape(309, 431, 616, 671)
         })

--- a/tests/cypress/integration/issue_1944_loading_screen_switch_job.js
+++ b/tests/cypress/integration/issue_1944_loading_screen_switch_job.js
@@ -27,6 +27,7 @@ context('Being able to return to the job list for a task and start a new job wit
     const archivePath = `cypress/fixtures/${archiveName}`
     const imagesFolder = `cypress/fixtures/image_issue_${issueId}`
     const directoryToArchive = imagesFolder
+    const advancedConfiguration = true
     const multiJobs = true
 
     before(() => {
@@ -40,7 +41,8 @@ context('Being able to return to the job list for a task and start a new job wit
 
     describe(`Testing issue "${issueId}"`, () => {
         it('Create a multijob task', () => {
-            cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, archiveName, multiJobs)
+            cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, archiveName,
+                false, '', '', '', advancedConfiguration, multiJobs)
         })
         it('Open the task. Open first job', () => {
             cy.openTaskJob(taskName)

--- a/tests/cypress/integration/issue_1944_loading_screen_switch_job.js
+++ b/tests/cypress/integration/issue_1944_loading_screen_switch_job.js
@@ -27,8 +27,10 @@ context('Being able to return to the job list for a task and start a new job wit
     const archivePath = `cypress/fixtures/${archiveName}`
     const imagesFolder = `cypress/fixtures/image_issue_${issueId}`
     const directoryToArchive = imagesFolder
-    const advancedConfiguration = true
-    const multiJobs = true
+    const advancedConfigurationParams = {
+        multiJobs: true,
+        segmentSize: 1
+    }
 
     before(() => {
         cy.visit('auth/login')
@@ -42,7 +44,7 @@ context('Being able to return to the job list for a task and start a new job wit
     describe(`Testing issue "${issueId}"`, () => {
         it('Create a multijob task', () => {
             cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, archiveName,
-                false, '', '', '', advancedConfiguration, multiJobs)
+                null, advancedConfigurationParams)
         })
         it('Open the task. Open first job', () => {
             cy.openTaskJob(taskName)

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -40,12 +40,18 @@ Cypress.Commands.add('createAnnotationTask', (taksName='New annotation task',
                                               attrName='Some attr name',
                                               textDefaultValue='Some default value for type Text',
                                               image='image.png',
-                                              multiJobs=false,
-                                              segmentSize=1,
                                               multiAttr=false,
                                               additionalAttrName,
                                               typeAttribute,
-                                              additionalValue) => {
+                                              additionalValue,
+                                              advancedConfiguration=false,
+                                              multiJobs,
+                                              segmentSize,
+                                              sssFrame,
+                                              startFrame,
+                                              stopFrame,
+                                              frameStep
+                                              ) => {
     cy.get('#cvat-create-task-button').click()
     cy.url().should('include', '/tasks/create')
     cy.get('[id="name"]').type(taksName)
@@ -61,10 +67,8 @@ Cypress.Commands.add('createAnnotationTask', (taksName='New annotation task',
     }
     cy.contains('button', 'Done').click()
     cy.get('input[type="file"]').attachFile(image, { subjectType: 'drag-n-drop' })
-    if (multiJobs) {
-        cy.contains('Advanced configuration').click()
-        cy.get('#segmentSize')
-        .type(segmentSize)
+    if (advancedConfiguration) {
+        cy.advancedConfiguration(multiJobs, segmentSize, sssFrame, startFrame, stopFrame, frameStep)
     }
     cy.contains('button', 'Submit').click()
     cy.contains('The task has been created')
@@ -263,4 +267,22 @@ Cypress.Commands.add('deleteTask', (taskName, taskID) => {
         cy.contains('button', 'Delete')
         .click()
     })
+})
+
+Cypress.Commands.add('advancedConfiguration', (multiJobs=false,
+                                                segmentSize=1,
+                                                sssFrame=false,
+                                                startFrame=1,
+                                                stopFrame=1,
+                                                frameStep=1) => {
+    cy.contains('Advanced configuration').click()
+    if (multiJobs) {
+        cy.get('#segmentSize')
+        .type(segmentSize)
+    }
+    if (sssFrame) {
+        cy.get('#startFrame').type(startFrame)
+        cy.get('#stopFrame').type(stopFrame)
+        cy.get('#frameStep').type(frameStep)
+    }
 })

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -40,17 +40,8 @@ Cypress.Commands.add('createAnnotationTask', (taksName='New annotation task',
                                               attrName='Some attr name',
                                               textDefaultValue='Some default value for type Text',
                                               image='image.png',
-                                              multiAttr=false,
-                                              additionalAttrName,
-                                              typeAttribute,
-                                              additionalValue,
-                                              advancedConfiguration=false,
-                                              multiJobs,
-                                              segmentSize,
-                                              sssFrame,
-                                              startFrame,
-                                              stopFrame,
-                                              frameStep
+                                              multiAttrParams,
+                                              advancedConfigurationParams
                                               ) => {
     cy.get('#cvat-create-task-button').click()
     cy.url().should('include', '/tasks/create')
@@ -62,13 +53,13 @@ Cypress.Commands.add('createAnnotationTask', (taksName='New annotation task',
     cy.get('div[title="Select"]').click()
     cy.get('li').contains('Text').click()
     cy.get('[placeholder="Default value"]').type(textDefaultValue)
-    if (multiAttr) {
-        cy.updateAttributes(additionalAttrName, typeAttribute, additionalValue)
+    if (multiAttrParams) {
+        cy.updateAttributes(multiAttrParams)
     }
     cy.contains('button', 'Done').click()
     cy.get('input[type="file"]').attachFile(image, { subjectType: 'drag-n-drop' })
-    if (advancedConfiguration) {
-        cy.advancedConfiguration(multiJobs, segmentSize, sssFrame, startFrame, stopFrame, frameStep)
+    if (advancedConfigurationParams) {
+        cy.advancedConfiguration(advancedConfigurationParams)
     }
     cy.contains('button', 'Submit').click()
     cy.contains('The task has been created')
@@ -217,12 +208,12 @@ Cypress.Commands.add('createCuboid', (mode, firstX, firstY, lastX, lastY) => {
     .click(lastX, lastY)
 })
 
-Cypress.Commands.add('updateAttributes', (additionalAttrName, typeAttribute, additionalValue) => {
+Cypress.Commands.add('updateAttributes', (multiAttrParams) => {
     cy.contains('button', 'Add an attribute').click()
-    cy.get('[placeholder="Name"]').first().type(additionalAttrName)
+    cy.get('[placeholder="Name"]').first().type(multiAttrParams.additionalAttrName)
     cy.get('div[title="Select"]').first().click()
-    cy.get('.ant-select-dropdown').last().contains(typeAttribute).click()
-    cy.get('[placeholder="Default value"]').first().type(additionalValue)
+    cy.get('.ant-select-dropdown').last().contains(multiAttrParams.typeAttribute).click()
+    cy.get('[placeholder="Default value"]').first().type(multiAttrParams.additionalValue)
 })
 
 Cypress.Commands.add('createPolyline', (mode,
@@ -269,20 +260,15 @@ Cypress.Commands.add('deleteTask', (taskName, taskID) => {
     })
 })
 
-Cypress.Commands.add('advancedConfiguration', (multiJobs=false,
-                                                segmentSize=1,
-                                                sssFrame=false,
-                                                startFrame=1,
-                                                stopFrame=1,
-                                                frameStep=1) => {
+Cypress.Commands.add('advancedConfiguration', (advancedConfigurationParams) => {
     cy.contains('Advanced configuration').click()
-    if (multiJobs) {
+    if (advancedConfigurationParams.multiJobs) {
         cy.get('#segmentSize')
-        .type(segmentSize)
+        .type(advancedConfigurationParams.segmentSize)
     }
-    if (sssFrame) {
-        cy.get('#startFrame').type(startFrame)
-        cy.get('#stopFrame').type(stopFrame)
-        cy.get('#frameStep').type(frameStep)
+    if (advancedConfigurationParams.sssFrame) {
+        cy.get('#startFrame').type(advancedConfigurationParams.startFrame)
+        cy.get('#stopFrame').type(advancedConfigurationParams.stopFrame)
+        cy.get('#frameStep').type(advancedConfigurationParams.frameStep)
     }
 })


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

Cypress test to check if parameters "startFrame", "stopFrame", "frameStep" works as expected

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
