### PR TITLE
Cypress test to check scale and fit image.

### DIFF
--- a/tests/cypress/integration/case_6_image_scale_fit.js
+++ b/tests/cypress/integration/case_6_image_scale_fit.js
@@ -39,7 +39,7 @@ context('Check if the image is scaled and then fitted', () => {
             .should('have.attr', 'style').and('contain', 'scale(0.8875)')
         })
         it('Fit image', () => {
-            cy.get('body')
+            cy.get('#cvat_canvas_content')
             .dblclick()
             cy.get('#cvat_canvas_background')
             .should('have.attr', 'style').and('contain', 'scale(1.065)')

--- a/tests/cypress/integration/case_6_image_scale_fit.js
+++ b/tests/cypress/integration/case_6_image_scale_fit.js
@@ -6,7 +6,7 @@
 
 /// <reference types="cypress" />
 
-context('Check if the image is rotated', () => {
+context('Check if the image is scaled and then fitted', () => {
 
     const caseId = '6'
     const labelName = `Case ${caseId}`

--- a/tests/cypress/integration/case_6_image_scale_fit.js
+++ b/tests/cypress/integration/case_6_image_scale_fit.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/// <reference types="cypress" />
+
+context('Check if the image is rotated', () => {
+
+    const caseId = '6'
+    const labelName = `Case ${caseId}`
+    const taskName = `New annotation task for ${labelName}`
+    const attrName = `Attr for ${labelName}`
+    const textDefaultValue = 'Some default value for type Text'
+    const imageFileName = `image_${labelName.replace(' ', '_').toLowerCase()}`
+    const image = `${imageFileName}.png`
+    const width = 800
+    const height = 800
+    const posX = 10
+    const posY = 10
+    const color = 'gray'
+
+    before(() => {
+        cy.visit('auth/login')
+        cy.login()
+        cy.imageGenerator('cypress/fixtures', image, width, height, color, posX, posY, labelName)
+        cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, image)
+        cy.openTaskJob(taskName)
+    })
+
+    describe(`Testing "${labelName}"`, () => {
+        it('Scale image', () => {
+            cy.get('#cvat_canvas_background')
+            .should('have.attr', 'style').and('contain', 'scale(1.065)')
+            cy.get('.cvat-canvas-container')
+            .trigger('wheel', {deltaY: 5})
+            cy.get('#cvat_canvas_background')
+            .should('have.attr', 'style').and('contain', 'scale(0.8875)')
+        })
+        it('Fit image', () => {
+            cy.get('body')
+            .dblclick()
+            cy.get('#cvat_canvas_background')
+            .should('have.attr', 'style').and('contain', 'scale(1.065)')
+        })
+    })
+})


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

Cypress test to check scale and fit image.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
