### PR TITLE
Raw image copying in dataset export

### DIFF
--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -13,7 +13,7 @@ import datumaro.components.extractor as datumaro
 from cvat.apps.engine.frame_provider import FrameProvider
 from cvat.apps.engine.models import AttributeType, ShapeType
 from datumaro.util import cast
-from datumaro.util.image import ByteImage
+from datumaro.util.image import ByteImage, Image
 
 from .annotation import AnnotationManager, TrackManager
 
@@ -457,21 +457,37 @@ class CvatTaskDataExtractor(datumaro.SourceExtractor):
 
         dm_items = []
 
-        frame_ext = FrameProvider.VIDEO_FRAME_EXT \
-            if task_data.meta['task']['mode'] == 'interpolation' \
-            else None
+        is_video = task_data.meta['task']['mode'] == 'interpolation'
+        ext = ''
+        if is_video:
+            ext = FrameProvider.VIDEO_FRAME_EXT
         if include_images:
             frame_provider = FrameProvider(task_data.db_task.data)
+            if is_video:
+                # optimization for videos: use numpy arrays instead of bytes
+                # some formats or transforms can require image data
+                def _make_image(i, **kwargs):
+                    loader = lambda _: frame_provider.get_frame(i,
+                        quality=frame_provider.Quality.ORIGINAL,
+                        out_type=frame_provider.Type.NUMPY_ARRAY)[0]
+                    return Image(loader=loader, **kwargs)
+            else:
+                # for images use encoded data to avoid recoding
+                def _make_image(i, **kwargs):
+                    loader = lambda _: frame_provider.get_frame(i,
+                        quality=frame_provider.Quality.ORIGINAL,
+                        out_type=frame_provider.Type.BUFFER)[0].getvalue()
+                    return ByteImage(data=loader, **kwargs)
 
         for frame_data in task_data.group_by_frame(include_empty=True):
-            loader = None
+            image_args = {
+                'path': frame_data.name + ext,
+                'size': (frame_data.height, frame_data.width),
+            }
             if include_images:
-                loader = lambda p, i=frame_data.idx: frame_provider.get_frame(i,
-                    quality=frame_provider.Quality.ORIGINAL,
-                    out_type=frame_provider.Type.BUFFER)[0].getvalue()
-            dm_image = ByteImage(path=frame_data.name, data=loader,
-                size=(frame_data.height, frame_data.width), ext=frame_ext
-            )
+                dm_image = _make_image(frame_data.idx, **image_args)
+            else:
+                dm_image = Image(**image_args)
             dm_anno = self._read_cvat_anno(frame_data, task_data)
             dm_item = datumaro.DatasetItem(id=osp.splitext(frame_data.name)[0],
                 annotations=dm_anno, image=dm_image,

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -13,7 +13,7 @@ import datumaro.components.extractor as datumaro
 from cvat.apps.engine.frame_provider import FrameProvider
 from cvat.apps.engine.models import AttributeType, ShapeType
 from datumaro.util import cast
-from datumaro.util.image import BytesImage
+from datumaro.util.image import ByteImage
 
 from .annotation import AnnotationManager, TrackManager
 
@@ -469,7 +469,7 @@ class CvatTaskDataExtractor(datumaro.SourceExtractor):
                 loader = lambda p, i=frame_data.idx: frame_provider.get_frame(i,
                     quality=frame_provider.Quality.ORIGINAL,
                     out_type=frame_provider.Type.BUFFER)[0].getvalue()
-            dm_image = BytesImage(path=frame_data.name, data=loader,
+            dm_image = ByteImage(path=frame_data.name, data=loader,
                 size=(frame_data.height, frame_data.width), ext=frame_ext
             )
             dm_anno = self._read_cvat_anno(frame_data, task_data)

--- a/cvat/apps/dataset_manager/formats/cvat.py
+++ b/cvat/apps/dataset_manager/formats/cvat.py
@@ -531,6 +531,10 @@ def _export(dst_file, task_data, anno_callback, save_images=False):
             anno_callback(f, task_data)
 
         if save_images:
+            ext = ''
+            if task_data.meta['task']['mode'] == 'interpolation':
+                ext = FrameProvider.VIDEO_FRAME_EXT
+
             img_dir = osp.join(temp_dir, 'images')
             frame_provider = FrameProvider(task_data.db_task.data)
             frames = frame_provider.get_frames(
@@ -538,9 +542,6 @@ def _export(dst_file, task_data, anno_callback, save_images=False):
                 frame_provider.Type.BUFFER)
             for frame_id, (frame_data, _) in enumerate(frames):
                 frame_name = task_data.frame_info[frame_id]['path']
-                ext = ''
-                if not '.' in osp.basename(frame_name):
-                    ext = '.png'
                 img_path = osp.join(img_dir, frame_name + ext)
                 os.makedirs(osp.dirname(img_path), exist_ok=True)
                 with open(img_path, 'wb') as f:

--- a/cvat/apps/engine/frame_provider.py
+++ b/cvat/apps/engine/frame_provider.py
@@ -135,9 +135,7 @@ class FrameProvider:
     @classmethod
     def _av_frame_to_png_bytes(cls, av_frame):
         ext = cls.VIDEO_FRAME_EXT
-        image = av_frame.to_ndarray()
-        if len(image.shape) == 3 and image.shape[2] in {3, 4}:
-            image[:, :, :3] = image[:, :, 2::-1] # RGB to BGR
+        image = av_frame.to_ndarray(format='bgr24')
         success, result = cv2.imencode(ext, image)
         if not success:
             raise Exception("Failed to encode image to '%s' format" % (ext))
@@ -150,11 +148,11 @@ class FrameProvider:
             return frame.to_image() if reader_class is VideoReader else Image.open(frame)
         elif out_type == self.Type.NUMPY_ARRAY:
             if reader_class is VideoReader:
-                image = frame.to_ndarray()
+                image = frame.to_ndarray(format='bgr24')
             else:
                 image = np.array(Image.open(frame))
-            if len(image.shape) == 3 and image.shape[2] in {3, 4}:
-                image[:, :, :3] = image[:, :, 2::-1] # RGB to BGR
+                if len(image.shape) == 3 and image.shape[2] in {3, 4}:
+                    image[:, :, :3] = image[:, :, 2::-1] # RGB to BGR
             return image
         else:
             raise Exception('unsupported output type')

--- a/cvat/apps/engine/frame_provider.py
+++ b/cvat/apps/engine/frame_provider.py
@@ -42,6 +42,9 @@ class RandomAccessIterator:
         self.pos = -1
 
 class FrameProvider:
+    VIDEO_FRAME_EXT = 'PNG'
+    VIDEO_FRAME_MIME = 'image/png'
+
     class Quality(Enum):
         COMPRESSED = 0
         ORIGINAL = 100
@@ -128,11 +131,11 @@ class FrameProvider:
 
         return chunk_number_
 
-    @staticmethod
-    def _av_frame_to_png_bytes(av_frame):
+    @classmethod
+    def _av_frame_to_png_bytes(cls, av_frame):
         pil_img = av_frame.to_image()
         buf = BytesIO()
-        pil_img.save(buf, format='PNG')
+        pil_img.save(buf, format=cls.VIDEO_FRAME_EXT)
         buf.seek(0)
         return buf
 
@@ -170,7 +173,7 @@ class FrameProvider:
 
         frame = self._convert_frame(frame, loader.reader_class, out_type)
         if loader.reader_class is VideoReader:
-            return (frame, 'image/png')
+            return (frame, self.VIDEO_FRAME_MIME)
         return (frame, mimetypes.guess_type(frame_name))
 
     def get_frames(self, quality=Quality.ORIGINAL, out_type=Type.BUFFER):

--- a/cvat/apps/engine/frame_provider.py
+++ b/cvat/apps/engine/frame_provider.py
@@ -6,6 +6,7 @@ import math
 from enum import Enum
 from io import BytesIO
 
+import cv2
 import numpy as np
 from PIL import Image
 
@@ -42,7 +43,7 @@ class RandomAccessIterator:
         self.pos = -1
 
 class FrameProvider:
-    VIDEO_FRAME_EXT = 'PNG'
+    VIDEO_FRAME_EXT = '.PNG'
     VIDEO_FRAME_MIME = 'image/png'
 
     class Quality(Enum):
@@ -133,11 +134,14 @@ class FrameProvider:
 
     @classmethod
     def _av_frame_to_png_bytes(cls, av_frame):
-        pil_img = av_frame.to_image()
-        buf = BytesIO()
-        pil_img.save(buf, format=cls.VIDEO_FRAME_EXT)
-        buf.seek(0)
-        return buf
+        ext = cls.VIDEO_FRAME_EXT
+        image = av_frame.to_ndarray()
+        if len(image.shape) == 3 and image.shape[2] in {3, 4}:
+            image[:, :, :3] = image[:, :, 2::-1] # RGB to BGR
+        success, result = cv2.imencode(ext, image)
+        if not success:
+            raise Exception("Failed to encode image to '%s' format" % (ext))
+        return BytesIO(result.tobytes())
 
     def _convert_frame(self, frame, reader_class, out_type):
         if out_type == self.Type.BUFFER:
@@ -146,7 +150,7 @@ class FrameProvider:
             return frame.to_image() if reader_class is VideoReader else Image.open(frame)
         elif out_type == self.Type.NUMPY_ARRAY:
             if reader_class is VideoReader:
-                image = np.array(frame.to_image())
+                image = frame.to_ndarray()
             else:
                 image = np.array(Image.open(frame))
             if len(image.shape) == 3 and image.shape[2] in {3, 4}:

--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -235,6 +235,8 @@ class VideoReader(IMediaReader):
         return pos / stream.duration if stream.duration else None
 
     def _get_av_container(self):
+        if isinstance(self._source_path[0], io.BytesIO):
+            self._source_path[0].seek(0) # required for re-reading
         return av.open(self._source_path[0])
 
     def get_preview(self):

--- a/cvat/requirements/base.txt
+++ b/cvat/requirements/base.txt
@@ -44,4 +44,4 @@ tensorflow==2.2.0 # Optional requirement of Datumaro
 # archives. Don't use as a python module because it has GPL license.
 patool==1.12
 diskcache==5.0.2
-git+https://github.com/openvinotoolkit/datumaro@v0.1.0
+git+https://github.com/openvinotoolkit/datumaro@v0.1.2


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Depends on https://github.com/openvinotoolkit/datumaro/pull/27

- Allows to copy raw images instead of recoding on dataset export
- Improves dataset export performance (4-6x +)

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```

TBD: 
test on a large video with chunks and cache enabled, check `top` output
- memory leaking (extracted to https://github.com/openvinotoolkit/cvat/issues/2241). To reproduce:
```python
import gc
import tracemalloc
tracemalloc.start(10)
try:    
    from cvat.apps.engine.models import Task
    from cvat.apps.engine.frame_provider import FrameProvider
    fp = FrameProvider(Task.objects.get(pk=39).data) # a large video task

    while True:
        for i, f in enumerate(fp.get_frames(out_type=fp.Type.NUMPY_ARRAY)):
            pass

except:    
    del fp
    del f
    snapshot = tracemalloc.take_snapshot()    
    gc.collect()
```
- [x] very slow work (blame debugger?) - NO, blame Pillow and image conversion