### PR TITLE
Dockercompose version update 2.3 --> 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Right colors of label tags in label mapping when a user runs automatic detection (<https://github.com/openvinotoolkit/cvat/pull/2162>)
 - Nuclio became an optional component of CVAT (<https://github.com/openvinotoolkit/cvat/pull/2192>)
 - A key to remove a point from a polyshape [Ctrl => Alt] (<https://github.com/openvinotoolkit/cvat/pull/2204>)
+- Updated `docker-compose` file version from `2.3` to `3.3`
 
 ### Deprecated
 -

--- a/components/analytics/docker-compose.analytics.yml
+++ b/components/analytics/docker-compose.analytics.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '3.3'
 services:
   cvat_elasticsearch:
     container_name: cvat_elasticsearch

--- a/components/serverless/docker-compose.serverless.yml
+++ b/components/serverless/docker-compose.serverless.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '3.3'
 services:
   serverless:
     container_name: nuclio

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,8 +3,8 @@ version: "3.3"
 services:
   cvat_ci:
     image: cvat_ci
+    network_mode: host
     build:
-      network: host
       context: .
       dockerfile: Dockerfile.ci
     depends_on:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,4 @@
-version: "2.3"
+version: "3.3"
 
 services:
   cvat_ci:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 #
-version: "2.3"
+version: "3.3"
 
 services:
   cvat_db:
@@ -98,9 +98,9 @@ services:
 networks:
   default:
     ipam:
+      driver: default
       config:
         - subnet: 172.28.0.0/24
-          gateway: 172.28.0.1
 
 volumes:
   cvat_db:


### PR DESCRIPTION
### Motivation and Context
Resolves #2232 
I have removed the `gateway` key because it was not supported in dockercompose file [version3](https://github.com/docker/docker.github.io/pull/1636). But, if you specify subnet, docker automatically choose relevant [gateway](https://docs.docker.com/engine/reference/commandline/network_create/#specify-advanced-options). So, dockercompose network gateway is still `172.28.0.1`.
Moreover, I have added `driver` key with `default` value. docker-compose was already using default value.

### Checklist
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] ~~I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [x] I have linked related issues 
- [ ] ~~I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] ~~I have updated the license header for each file (see an example below)~~
