### PR TITLE
Cypress. Saving the label name before creating the object.

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_10_polygon_shape_track_label_points.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_10_polygon_shape_track_label_points.js
@@ -103,57 +103,15 @@ context('Actions on polygon', () => {
         });
         it('Draw a polygon shape, track', () => {
             cy.createPolygon(createPolygonShape);
-            cy.get('#cvat_canvas_shape_1').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-1')
-                .should('contain', '1')
-                .and('contain', 'POLYGON SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
             cy.createPolygon(createPolygonTrack);
-            cy.get('#cvat_canvas_shape_2').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-2')
-                .should('contain', '2')
-                .and('contain', 'POLYGON TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
         });
         it('Draw a polygon shape, track with use parameter "number of points"', () => {
             cy.createPolygon(createPolygonShapePoints);
-            cy.get('#cvat_canvas_shape_3').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-3')
-                .should('contain', '3')
-                .and('contain', 'POLYGON SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
             cy.createPolygon(createPolygonTrackPoints);
-            cy.get('#cvat_canvas_shape_4').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-4')
-                .should('contain', '4')
-                .and('contain', 'POLYGON TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
         });
         it('Draw a polygon shape, track with second label', () => {
             cy.createPolygon(createPolygonShapeSwitchLabel);
-            cy.get('#cvat_canvas_shape_5').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-5')
-                .should('contain', '5')
-                .and('contain', 'POLYGON SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', newLabelName);
-                });
             cy.createPolygon(createPolygonTrackSwitchLabel);
-            cy.get('#cvat_canvas_shape_6').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-6')
-                .should('contain', '6')
-                .and('contain', 'POLYGON TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', newLabelName);
-                });
         });
     });
 });

--- a/tests/cypress/integration/actions_tasks_objects/case_11_polylines_shape_track_label_points.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_11_polylines_shape_track_label_points.js
@@ -98,57 +98,15 @@ context('Actions on polylines', () => {
         });
         it('Draw a polylines shape, track', () => {
             cy.createPolyline(createPolylinesShape);
-            cy.get('#cvat_canvas_shape_1').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-1')
-                .should('contain', '1')
-                .and('contain', 'POLYLINE SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
             cy.createPolyline(createPolylinesTrack);
-            cy.get('#cvat_canvas_shape_2').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-2')
-                .should('contain', '2')
-                .and('contain', 'POLYLINE TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
         });
         it('Draw a polylines shape, track with use parameter "number of points"', () => {
             cy.createPolyline(createPolylinesShapePoints);
-            cy.get('#cvat_canvas_shape_3').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-3')
-                .should('contain', '3')
-                .and('contain', 'POLYLINE SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
             cy.createPolyline(createPolylinesTrackPoints);
-            cy.get('#cvat_canvas_shape_4').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-4')
-                .should('contain', '4')
-                .and('contain', 'POLYLINE TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
         });
         it('Draw a polylines shape, track with second label', () => {
             cy.createPolyline(createPolylinesShapeSwitchLabel);
-            cy.get('#cvat_canvas_shape_5').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-5')
-                .should('contain', '5')
-                .and('contain', 'POLYLINE SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', newLabelName);
-                });
             cy.createPolyline(createPolylinesTrackSwitchLabel);
-            cy.get('#cvat_canvas_shape_6').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-6')
-                .should('contain', '6')
-                .and('contain', 'POLYLINE TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', newLabelName);
-                });
         });
     });
 });

--- a/tests/cypress/integration/actions_tasks_objects/case_12_points_shape_track_label.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_12_points_shape_track_label.js
@@ -97,57 +97,15 @@ context('Actions on points', () => {
         });
         it('Draw a points shape, track', () => {
             cy.createPoint(createPointsShape);
-            cy.get('#cvat_canvas_shape_1').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-1')
-                .should('contain', '1')
-                .and('contain', 'POINTS SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
             cy.createPoint(createPointsTrack);
-            cy.get('#cvat_canvas_shape_2').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-2')
-                .should('contain', '2')
-                .and('contain', 'POINTS TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
         });
         it('Draw a points shape, track with use parameter "number of points"', () => {
             cy.createPoint(createPointsShapePoints);
-            cy.get('#cvat_canvas_shape_3').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-3')
-                .should('contain', '3')
-                .and('contain', 'POINTS SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
             cy.createPoint(createPointsTrackPoints);
-            cy.get('#cvat_canvas_shape_4').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-4')
-                .should('contain', '4')
-                .and('contain', 'POINTS TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
         });
         it('Draw a points shape, track with second label', () => {
             cy.createPoint(createPointsShapeSwitchLabel);
-            cy.get('#cvat_canvas_shape_5').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-5')
-                .should('contain', '5')
-                .and('contain', 'POINTS SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', newLabelName);
-                });
             cy.createPoint(createPointsTrackSwitchLabel);
-            cy.get('#cvat_canvas_shape_6').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-6')
-                .should('contain', '6')
-                .and('contain', 'POINTS TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', newLabelName);
-                });
         });
     });
 });

--- a/tests/cypress/integration/actions_tasks_objects/case_8_rectangle_shape_track_label.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_8_rectangle_shape_track_label.js
@@ -95,57 +95,15 @@ context('Actions on rectangle', () => {
         });
         it('Draw a rectangle shape in two ways (by 2 points, by 4 points)', () => {
             cy.createRectangle(createRectangleShape2Points);
-            cy.get('#cvat_canvas_shape_1').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-1')
-                .should('contain', '1')
-                .and('contain', 'RECTANGLE SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
             cy.createRectangle(createRectangleShape4Points);
-            cy.get('#cvat_canvas_shape_2').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-2')
-                .should('contain', '2')
-                .and('contain', 'RECTANGLE SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
         });
         it('Draw a rectangle track in two ways (by 2 points, by 4 points)', () => {
             cy.createRectangle(createRectangleTrack2Points);
-            cy.get('#cvat_canvas_shape_3').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-3')
-                .should('contain', '3')
-                .and('contain', 'RECTANGLE TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
             cy.createRectangle(createRectangleTrack4Points);
-            cy.get('#cvat_canvas_shape_4').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-4')
-                .should('contain', '4')
-                .and('contain', 'RECTANGLE TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
         });
         it('Draw a new rectangle shape in two ways (by 2 points, by 4 points) with second label', () => {
             cy.createRectangle(createRectangleShape2PointsNewLabel);
-            cy.get('#cvat_canvas_shape_5').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-5')
-                .should('contain', '5')
-                .and('contain', 'RECTANGLE SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', newLabelName);
-                });
             cy.createRectangle(createRectangleShape4PointsNewLabel);
-            cy.get('#cvat_canvas_shape_6').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-6')
-                .should('contain', '6')
-                .and('contain', 'RECTANGLE SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', newLabelName);
-                });
         });
     });
 });

--- a/tests/cypress/integration/actions_tasks_objects/case_9_cuboid_shape_track_label.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_9_cuboid_shape_track_label.js
@@ -95,57 +95,15 @@ context('Actions on Cuboid', () => {
         });
         it('Draw a Cuboid shape in two ways (From rectangle, by 4 points)', () => {
             cy.createCuboid(createCuboidShape2Points);
-            cy.get('#cvat_canvas_shape_1').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-1')
-                .should('contain', '1')
-                .and('contain', 'CUBOID SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
             cy.createCuboid(createCuboidShape4Points);
-            cy.get('#cvat_canvas_shape_2').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-2')
-                .should('contain', '2')
-                .and('contain', 'CUBOID SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
         });
         it('Draw a Cuboid track in two ways (From rectangle, by 4 points)', () => {
             cy.createCuboid(createCuboidTrack2Points);
-            cy.get('#cvat_canvas_shape_3').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-3')
-                .should('contain', '3')
-                .and('contain', 'CUBOID TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
             cy.createCuboid(createCuboidTrack4Points);
-            cy.get('#cvat_canvas_shape_4').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-4')
-                .should('contain', '4')
-                .and('contain', 'CUBOID TRACK')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', labelName);
-                });
         });
         it('Draw a new Cuboid shape in two ways (From rectangle, by 4 points) with second label', () => {
             cy.createCuboid(createCuboidShape2PointsNewLabel);
-            cy.get('#cvat_canvas_shape_5').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-5')
-                .should('contain', '5')
-                .and('contain', 'CUBOID SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', newLabelName);
-                });
             cy.createCuboid(createCuboidShape4PointsNewLabel);
-            cy.get('#cvat_canvas_shape_6').should('exist').and('be.visible');
-            cy.get('#cvat-objects-sidebar-state-item-6')
-                .should('contain', '6')
-                .and('contain', 'CUBOID SHAPE')
-                .within(() => {
-                    cy.get('.ant-select-selection-selected-value').should('contain', newLabelName);
-                });
         });
     });
 });

--- a/tests/cypress/integration/actions_tasks_objects/issue_1425_highlighted_attribute_correspond_chosen_attribute.js
+++ b/tests/cypress/integration/actions_tasks_objects/issue_1425_highlighted_attribute_correspond_chosen_attribute.js
@@ -6,7 +6,7 @@
 
 /// <reference types="cypress" />
 
-import { taskName } from '../../support/const';
+import { taskName, labelName } from '../../support/const';
 
 context('The highlighted attribute in AAM should correspond to the chosen attribute', () => {
     const issueId = '1425';
@@ -31,6 +31,11 @@ context('The highlighted attribute in AAM should correspond to the chosen attrib
         });
         it('Go to AAM', () => {
             cy.changeAnnotationMode('Attribute annotation');
+            // Select the necessary label in any case
+            cy.get('.attribute-annotation-sidebar-basics-editor').within(() => {
+                cy.get('.ant-select-selection').click();
+            });
+            cy.get('.ant-select-dropdown-menu-item').contains(labelName).click();
         });
         it('Check if highlighted attribute correspond to the chosen attribute in right panel', () => {
             cy.get('.cvat_canvas_text').within(() => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -10,6 +10,8 @@ require('cypress-file-upload');
 require('../plugins/imageGenerator/imageGeneratorCommand');
 require('../plugins/createZipArchive/createZipArchiveCommand');
 
+let selectedValueGlobal = '';
+
 Cypress.Commands.add('login', (username = Cypress.env('user'), password = Cypress.env('password')) => {
     cy.get('[placeholder="Username"]').type(username);
     cy.get('[placeholder="Password"]').type(password);
@@ -99,22 +101,36 @@ Cypress.Commands.add('createRectangle', (createRectangleParams) => {
     if (createRectangleParams.switchLabel) {
         cy.switchLabel(createRectangleParams.labelName);
     }
-    cy.get('.cvat-draw-shape-popover-content').contains(createRectangleParams.points).click();
-    cy.get('.cvat-draw-shape-popover-content')
-        .find('button')
-        .contains(createRectangleParams.type)
-        .click({ force: true });
+    cy.contains('Draw new rectangle')
+    .parents('.cvat-draw-shape-popover-content').within(() => {
+        cy.get('.ant-select-selection-selected-value').then(($labelValue) => {
+            selectedValueGlobal = $labelValue.text();
+        });
+        cy.get('.ant-radio-wrapper').contains(createRectangleParams.points).click();
+        cy.get('button').contains(createRectangleParams.type).click({ force: true });
+    })
     cy.get('.cvat-canvas-container').click(createRectangleParams.firstX, createRectangleParams.firstY);
     cy.get('.cvat-canvas-container').click(createRectangleParams.secondX, createRectangleParams.secondY);
     if (createRectangleParams.points === 'By 4 Points') {
         cy.get('.cvat-canvas-container').click(createRectangleParams.thirdX, createRectangleParams.thirdY);
         cy.get('.cvat-canvas-container').click(createRectangleParams.fourthX, createRectangleParams.fourthY);
     }
+    cy.checkObjectParameters(createRectangleParams, 'RECTANGLE');
 });
 
 Cypress.Commands.add('switchLabel', (labelName) => {
     cy.get('.cvat-draw-shape-popover-content').find('.ant-select-selection-selected-value').click();
     cy.get('.ant-select-dropdown-menu').contains(labelName).click();
+});
+
+Cypress.Commands.add('checkObjectParameters', (objectParameters, objectType) => {
+    cy.get('.cvat-objects-sidebar-state-item').then((objectSidebar) => {
+        cy.get(`#cvat_canvas_shape_${objectSidebar.length}`).should('exist').and('be.visible');
+        cy.get(`#cvat-objects-sidebar-state-item-${objectSidebar.length}`)
+        .should('contain', objectSidebar.length).and('contain', `${objectType} ${objectParameters.type.toUpperCase()}`).within(() => {
+            cy.get('.ant-select-selection-selected-value').should('have.text', selectedValueGlobal);
+        });
+    });
 });
 
 Cypress.Commands.add('createPoint', (createPointParams) => {
@@ -125,6 +141,9 @@ Cypress.Commands.add('createPoint', (createPointParams) => {
     cy.contains('Draw new points')
         .parents('.cvat-draw-shape-popover-content')
         .within(() => {
+            cy.get('.ant-select-selection-selected-value').then(($labelValue) => {
+                selectedValueGlobal = $labelValue.text();
+            });
             if (createPointParams.numberOfPoints) {
                 createPointParams.complete = false;
                 cy.get('.ant-input-number-input').clear().type(createPointParams.numberOfPoints);
@@ -137,6 +156,7 @@ Cypress.Commands.add('createPoint', (createPointParams) => {
     if (createPointParams.complete) {
         cy.get('.cvat-canvas-container').trigger('keydown', { key: 'n' }).trigger('keyup', { key: 'n' });
     }
+    cy.checkObjectParameters(createPointParams, 'POINTS');
 });
 
 Cypress.Commands.add('changeAppearance', (colorBy) => {
@@ -165,6 +185,9 @@ Cypress.Commands.add('createPolygon', (createPolygonParams) => {
         cy.contains('Draw new polygon')
             .parents('.cvat-draw-shape-popover-content')
             .within(() => {
+                cy.get('.ant-select-selection-selected-value').then(($labelValue) => {
+                    selectedValueGlobal = $labelValue.text();
+                });
                 if (createPolygonParams.numberOfPoints) {
                     createPolygonParams.complete = false;
                     cy.get('.ant-input-number-input').clear().type(createPolygonParams.numberOfPoints);
@@ -178,6 +201,7 @@ Cypress.Commands.add('createPolygon', (createPolygonParams) => {
     if (createPolygonParams.complete) {
         cy.get('.cvat-canvas-container').trigger('keydown', { key: 'n' }).trigger('keyup', { key: 'n' });
     }
+    cy.checkObjectParameters(createPolygonParams, 'POLYGON');
 });
 
 Cypress.Commands.add('openSettings', () => {
@@ -208,6 +232,9 @@ Cypress.Commands.add('createCuboid', (createCuboidParams) => {
     cy.contains('Draw new cuboid')
         .parents('.cvat-draw-shape-popover-content')
         .within(() => {
+            cy.get('.ant-select-selection-selected-value').then(($labelValue) => {
+                selectedValueGlobal = $labelValue.text();
+            });
             cy.get('button').contains(createCuboidParams.type).click({ force: true });
         });
     cy.get('.cvat-canvas-container').click(createCuboidParams.firstX, createCuboidParams.firstY);
@@ -216,6 +243,7 @@ Cypress.Commands.add('createCuboid', (createCuboidParams) => {
         cy.get('.cvat-canvas-container').click(createCuboidParams.thirdX, createCuboidParams.thirdY);
         cy.get('.cvat-canvas-container').click(createCuboidParams.fourthX, createCuboidParams.fourthY);
     }
+    cy.checkObjectParameters(createCuboidParams, 'CUBOID');
 });
 
 Cypress.Commands.add('updateAttributes', (multiAttrParams) => {
@@ -234,6 +262,9 @@ Cypress.Commands.add('createPolyline', (createPolylineParams) => {
     cy.contains('Draw new polyline')
         .parents('.cvat-draw-shape-popover-content')
         .within(() => {
+            cy.get('.ant-select-selection-selected-value').then(($labelValue) => {
+                selectedValueGlobal = $labelValue.text();
+            });
             if (createPolylineParams.numberOfPoints) {
                 createPolylineParams.complete = false;
                 cy.get('.ant-input-number-input').clear().type(createPolylineParams.numberOfPoints);
@@ -246,6 +277,7 @@ Cypress.Commands.add('createPolyline', (createPolylineParams) => {
     if (createPolylineParams.complete) {
         cy.get('.cvat-canvas-container').trigger('keydown', { key: 'n' }).trigger('keyup', { key: 'n' });
     }
+    cy.checkObjectParameters(createPolylineParams, 'POLYLINE');
 });
 
 Cypress.Commands.add('getTaskID', (taskName) => {


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

Cypress. Saving the label name before creating the object. 
Checking the main parameters of the created object moved to commands.js.

### Motivation and context
There were situations when a new shortcut added to the task was placed at the top of the list of shortcuts. In this case, when creating an object, the new shortcut is placed first in the drop-down menu. This may affect the passing of tests that check this value.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
