### PR TITLE
Fixed: Canvas is busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Django templates for email and user guide (<https://github.com/openvinotoolkit/cvat/pull/2412>)
 - Saving relative paths in dummy chunks instead of absolute(<https://github.com/openvinotoolkit/cvat/pull/2424>)
+- Canvas is busy error (<https://github.com/openvinotoolkit/cvat/pull/2437>)
 
 ### Security
 

--- a/cvat-ui/package-lock.json
+++ b/cvat-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.10.3",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-ui/package-lock.json
+++ b/cvat-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.10.0",
+  "version": "1.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.10.3",
+  "version": "1.10.1",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.10.0",
+  "version": "1.10.3",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/annotation-page/top-bar/player-buttons.tsx
+++ b/cvat-ui/src/components/annotation-page/top-bar/player-buttons.tsx
@@ -109,7 +109,7 @@ function PlayerButtons(props: Props): JSX.Element {
             <Popover
                 trigger='contextMenu'
                 placement='bottom'
-                content={
+                content={(
                     <>
                         <Tooltip title={`${prevRegularText}`} mouseLeaveDelay={0}>
                             <Icon
@@ -139,7 +139,7 @@ function PlayerButtons(props: Props): JSX.Element {
                             />
                         </Tooltip>
                     </>
-                }
+                )}
             >
                 <Tooltip
                     placement='top'
@@ -163,7 +163,7 @@ function PlayerButtons(props: Props): JSX.Element {
             <Popover
                 trigger='contextMenu'
                 placement='bottom'
-                content={
+                content={(
                     <>
                         <Tooltip title={`${nextRegularText}`} mouseLeaveDelay={0}>
                             <Icon
@@ -193,7 +193,7 @@ function PlayerButtons(props: Props): JSX.Element {
                             />
                         </Tooltip>
                     </>
-                }
+                )}
             >
                 <Tooltip placement='top' mouseLeaveDelay={0} title={`${nextButtonTooltipMessage} ${nextFrameShortcut}`}>
                     {nextButton}

--- a/cvat-ui/src/containers/annotation-page/top-bar/top-bar.tsx
+++ b/cvat-ui/src/containers/annotation-page/top-bar/top-bar.tsx
@@ -231,7 +231,9 @@ class AnnotationTopBarContainer extends React.PureComponent<Props, State> {
     }
 
     private undo = (): void => {
-        const { undo, jobInstance, frameNumber, canvasInstance } = this.props;
+        const {
+            undo, jobInstance, frameNumber, canvasInstance,
+        } = this.props;
 
         if (canvasInstance.isAbleToChangeFrame()) {
             undo(jobInstance, frameNumber);
@@ -239,7 +241,9 @@ class AnnotationTopBarContainer extends React.PureComponent<Props, State> {
     };
 
     private redo = (): void => {
-        const { redo, jobInstance, frameNumber, canvasInstance } = this.props;
+        const {
+            redo, jobInstance, frameNumber, canvasInstance,
+        } = this.props;
 
         if (canvasInstance.isAbleToChangeFrame()) {
             redo(jobInstance, frameNumber);
@@ -253,7 +257,9 @@ class AnnotationTopBarContainer extends React.PureComponent<Props, State> {
     };
 
     private onSwitchPlay = (): void => {
-        const { frameNumber, jobInstance, onSwitchPlay, playing } = this.props;
+        const {
+            frameNumber, jobInstance, onSwitchPlay, playing,
+        } = this.props;
 
         if (playing) {
             onSwitchPlay(false);
@@ -263,7 +269,9 @@ class AnnotationTopBarContainer extends React.PureComponent<Props, State> {
     };
 
     private onFirstFrame = (): void => {
-        const { frameNumber, jobInstance, playing, onSwitchPlay } = this.props;
+        const {
+            frameNumber, jobInstance, playing, onSwitchPlay,
+        } = this.props;
 
         const newFrame = jobInstance.startFrame;
         if (newFrame !== frameNumber) {
@@ -275,7 +283,9 @@ class AnnotationTopBarContainer extends React.PureComponent<Props, State> {
     };
 
     private onBackward = (): void => {
-        const { frameNumber, frameStep, jobInstance, playing, onSwitchPlay } = this.props;
+        const {
+            frameNumber, frameStep, jobInstance, playing, onSwitchPlay,
+        } = this.props;
 
         const newFrame = Math.max(jobInstance.startFrame, frameNumber - frameStep);
         if (newFrame !== frameNumber) {
@@ -288,7 +298,9 @@ class AnnotationTopBarContainer extends React.PureComponent<Props, State> {
 
     private onPrevFrame = (): void => {
         const { prevButtonType } = this.state;
-        const { frameNumber, jobInstance, playing, onSwitchPlay, searchAnnotations, searchEmptyFrame } = this.props;
+        const {
+            frameNumber, jobInstance, playing, onSwitchPlay,
+        } = this.props;
         const { startFrame } = jobInstance;
 
         const newFrame = Math.max(jobInstance.startFrame, frameNumber - 1);
@@ -296,19 +308,22 @@ class AnnotationTopBarContainer extends React.PureComponent<Props, State> {
             if (playing) {
                 onSwitchPlay(false);
             }
+
             if (prevButtonType === 'regular') {
                 this.changeFrame(newFrame);
             } else if (prevButtonType === 'filtered') {
-                searchAnnotations(jobInstance, frameNumber - 1, startFrame);
+                this.searchAnnotations(frameNumber - 1, startFrame);
             } else {
-                searchEmptyFrame(jobInstance, frameNumber - 1, startFrame);
+                this.searchEmptyFrame(frameNumber - 1, startFrame);
             }
         }
     };
 
     private onNextFrame = (): void => {
         const { nextButtonType } = this.state;
-        const { frameNumber, jobInstance, playing, onSwitchPlay, searchAnnotations, searchEmptyFrame } = this.props;
+        const {
+            frameNumber, jobInstance, playing, onSwitchPlay,
+        } = this.props;
         const { stopFrame } = jobInstance;
 
         const newFrame = Math.min(jobInstance.stopFrame, frameNumber + 1);
@@ -316,18 +331,21 @@ class AnnotationTopBarContainer extends React.PureComponent<Props, State> {
             if (playing) {
                 onSwitchPlay(false);
             }
+
             if (nextButtonType === 'regular') {
                 this.changeFrame(newFrame);
             } else if (nextButtonType === 'filtered') {
-                searchAnnotations(jobInstance, frameNumber + 1, stopFrame);
+                this.searchAnnotations(frameNumber + 1, stopFrame);
             } else {
-                searchEmptyFrame(jobInstance, frameNumber + 1, stopFrame);
+                this.searchEmptyFrame(frameNumber + 1, stopFrame);
             }
         }
     };
 
     private onForward = (): void => {
-        const { frameNumber, frameStep, jobInstance, playing, onSwitchPlay } = this.props;
+        const {
+            frameNumber, frameStep, jobInstance, playing, onSwitchPlay,
+        } = this.props;
 
         const newFrame = Math.min(jobInstance.stopFrame, frameNumber + frameStep);
         if (newFrame !== frameNumber) {
@@ -339,7 +357,9 @@ class AnnotationTopBarContainer extends React.PureComponent<Props, State> {
     };
 
     private onLastFrame = (): void => {
-        const { frameNumber, jobInstance, playing, onSwitchPlay } = this.props;
+        const {
+            frameNumber, jobInstance, playing, onSwitchPlay,
+        } = this.props;
 
         const newFrame = jobInstance.stopFrame;
         if (newFrame !== frameNumber) {
@@ -415,6 +435,20 @@ class AnnotationTopBarContainer extends React.PureComponent<Props, State> {
         const { onChangeFrame, canvasInstance } = this.props;
         if (canvasInstance.isAbleToChangeFrame()) {
             onChangeFrame(frame);
+        }
+    }
+
+    private searchAnnotations(start: number, stop: number): void {
+        const { canvasInstance, jobInstance, searchAnnotations } = this.props;
+        if (canvasInstance.isAbleToChangeFrame()) {
+            searchAnnotations(jobInstance, start, stop);
+        }
+    }
+
+    private searchEmptyFrame(start: number, stop: number): void {
+        const { canvasInstance, jobInstance, searchAnnotations } = this.props;
+        if (canvasInstance.isAbleToChangeFrame()) {
+            searchAnnotations(jobInstance, start, stop);
         }
     }
 


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Resolve #1922

### How has this been tested?
Manual testing
@dvkruchinin Could you please write a test for the issue.
Scenario is:
1. Open a job (should contain at least two images)
2. Draw a shape on the first image
3. Draw a shape on the second image
4. Switch player back button mode to "back with a filter" (right click by the button and select)
5. Start resizing (or dragging) a shape on the second frame
6. Press the shortcut [D] to go to the first frame
7. CVAT goes to fail view before the fix and nothing happens after fix

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
