### PR TITLE
Cypress test. Canvas color feature.

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_21_canvas_color_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_21_canvas_color_feature.js
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName } from '../../support/const';
+
+context('Canvas color feature', () => {
+    const caseId = '21';
+
+    before(() => {
+        cy.openTaskJob(taskName);
+    });
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Go to settings', () => {
+            cy.openSettings();
+        });
+        it('Change canvas background color. Color has been changed', () => {
+            cy.get('.cvat-player-settings-canvas-background').within(() => {
+                cy.get('button').click();
+            });
+            cy.get('.canvas-background-color-picker-popover')
+                .find('div[title]')
+                .then((colorPicker) => {
+                    for (let i = 0; i < colorPicker.length; i++) {
+                        cy.get(colorPicker[i])
+                            .click()
+                            .should('have.css', 'background')
+                            .then((colorPickerBgValue) => {
+                                cy.get('.cvat-canvas-container')
+                                    .should('have.css', 'background-color')
+                                    .then((canvasBgColor) => {
+                                        //For each color change, compare the value with the css value background-color of .cvat-canvas-container
+                                        expect(String(colorPickerBgValue.match(/^.*\d+, \d+, \d+\)/))).to.be.equal(
+                                            canvasBgColor,
+                                        );
+                                    });
+                            });
+                    }
+                });
+        });
+    });
+});

--- a/tests/cypress/integration/actions_tasks_objects/case_21_canvas_color_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_21_canvas_color_feature.js
@@ -27,15 +27,13 @@ context('Canvas color feature', () => {
                     for (let i = 0; i < colorPicker.length; i++) {
                         cy.get(colorPicker[i])
                             .click()
-                            .should('have.css', 'background')
+                            .should('have.css', 'background-color')
                             .then((colorPickerBgValue) => {
                                 cy.get('.cvat-canvas-container')
                                     .should('have.css', 'background-color')
                                     .then((canvasBgColor) => {
                                         //For each color change, compare the value with the css value background-color of .cvat-canvas-container
-                                        expect(String(colorPickerBgValue.match(/^.*\d+, \d+, \d+\)/))).to.be.equal(
-                                            canvasBgColor,
-                                        );
+                                        expect(colorPickerBgValue).to.be.equal(canvasBgColor);
                                     });
                             });
                     }


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Cypress test. Canvas color feature.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
