### PR TITLE
Cypress test. Delete unlock and lock object.

### DIFF
--- a/cvat-ui/package-lock.json
+++ b/cvat-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-menu.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-menu.tsx
@@ -200,6 +200,7 @@ function RemoveItem(props: ItemProps): JSX.Element {
                     onClick={(): void => {
                         if (locked) {
                             Modal.confirm({
+								className: 'cvat-modal-confirm',
                                 title: 'Object is locked',
                                 content: 'Are you sure you want to remove it?',
                                 onOk() {

--- a/cvat-ui/src/components/cvat-app.tsx
+++ b/cvat-ui/src/components/cvat-app.tsx
@@ -187,9 +187,11 @@ class CVATApplication extends React.PureComponent<CVATAppProps & RouteComponentP
     }
 
     private showErrors(): void {
-        function showError(title: string, _error: any): void {
+        function showError(title: string, _error: any, className?: string): void {
             const error = _error.toString();
+            const dynamicProps = typeof className === 'undefined' ? {} : { className };
             notification.error({
+                ...dynamicProps,
                 message: (
                     <div
                         // eslint-disable-next-line
@@ -214,7 +216,7 @@ class CVATApplication extends React.PureComponent<CVATAppProps & RouteComponentP
                 const error = (notifications as any).errors[where][what];
                 shown = shown || !!error;
                 if (error) {
-                    showError(error.message, error.reason);
+                    showError(error.message, error.reason, error.className);
                 }
             }
         }

--- a/cvat-ui/src/reducers/interfaces.ts
+++ b/cvat-ui/src/reducers/interfaces.ts
@@ -213,6 +213,7 @@ export interface ModelsState {
 export interface ErrorState {
     message: string;
     reason: string;
+    className?: string;
 }
 
 export interface NotificationsState {

--- a/cvat-ui/src/reducers/notifications-reducer.ts
+++ b/cvat-ui/src/reducers/notifications-reducer.ts
@@ -776,6 +776,7 @@ export default function (state = defaultState, action: AnyAction): Notifications
                         removing: {
                             message: 'Could not remove the object',
                             reason: action.payload.error.toString(),
+                            className: 'cvat-notification-notice-remove-object-failed',
                         },
                     },
                 },

--- a/tests/cypress/integration/actions_tasks_objects/case_24_delete_unlock_lock_object.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_24_delete_unlock_lock_object.js
@@ -38,8 +38,7 @@ context('Delete unlock/lock object', () => {
     };
 
     function clickRemoveOnDropdownMenu() {
-        cy.get('.ant-dropdown')
-            .not('.ant-dropdown-hidden')
+        cy.get('.cvat-object-item-menu')
             .contains(new RegExp('^Remove$', 'g'))
             .click({ force: true });
     };
@@ -68,7 +67,7 @@ context('Delete unlock/lock object', () => {
     };
 
     function actionOnConfirmWindow(textBuntton) {
-        cy.get('.ant-modal-confirm').within(() => {
+        cy.get('.cvat-modal-confirm').within(() => {
             cy.contains(new RegExp(`^${textBuntton}$`, 'g'))
                 .click();
         });
@@ -77,7 +76,7 @@ context('Delete unlock/lock object', () => {
     function checkFailDeleteLockObject(shortcut) {
         deleteObjectViaShortcut(shortcut, 'lock');
         checkExistObject('exist');
-        cy.get('.ant-notification-topRight').should('exist');
+        cy.get('.cvat-notification-notice-remove-object-failed').should('exist');
     };
 
     function checkExistObject(state) {

--- a/tests/cypress/integration/actions_tasks_objects/case_24_delete_unlock_lock_object.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_24_delete_unlock_lock_object.js
@@ -47,6 +47,13 @@ context('Delete unlock/lock object', () => {
         });
     };
 
+    function checkFailDeleteLockObject(shortcut) {
+        deleteObjectViaShortcut(shortcut);
+        cy.get('rect.cvat_canvas_shape').should('exist');
+        cy.get('div.cvat-objects-sidebar-state-item').should('exist');
+        cy.contains('.ant-notification-topRight', 'Error: Could not remove the locked object').should('exist');
+    };
+
     function checkExistObject() {
         cy.get('rect.cvat_canvas_shape').should('not.exist');
         cy.get('div.cvat-objects-sidebar-state-item').should('not.exist');
@@ -72,6 +79,7 @@ context('Delete unlock/lock object', () => {
         it('Create, lock and delete object via "Shift+Delete" shortcuts', () => {
             cy.createRectangle(createRectangleShape2Points);
             lockObject();
+            checkFailDeleteLockObject('{del}');
             deleteObjectViaShortcut('{shift}{del}');
             checkExistObject();
         });

--- a/tests/cypress/integration/actions_tasks_objects/case_24_delete_unlock_lock_object.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_24_delete_unlock_lock_object.js
@@ -76,18 +76,13 @@ context('Delete unlock/lock object', () => {
 
     function checkFailDeleteLockObject(shortcut) {
         deleteObjectViaShortcut(shortcut, 'lock');
-        checkExistObject();
+        checkExistObject('exist');
         cy.get('.ant-notification-topRight').should('exist');
     };
 
-    function checkExistObject() {
-        cy.get('.cvat_canvas_shape').should('exist');
-        cy.get('.cvat-objects-sidebar-state-item').should('exist');
-    };
-
-    function checkNotExistObject() {
-        cy.get('.cvat_canvas_shape').should('not.exist');
-        cy.get('.cvat-objects-sidebar-state-item').should('not.exist');
+    function checkExistObject(state) {
+        cy.get('.cvat_canvas_shape').should(state);
+        cy.get('.cvat-objects-sidebar-state-item').should(state);
     };
 
     before(() => {
@@ -98,13 +93,13 @@ context('Delete unlock/lock object', () => {
         it('Create and delete object via "Delete" shortcut', () => {
             cy.createRectangle(createRectangleShape2Points);
             deleteObjectViaShortcut('{del}', 'unlock');
-            checkNotExistObject();
+            checkExistObject('not.exist');
         });
 
         it('Create and delete object via GUI from sidebar', () => {
             cy.createRectangle(createRectangleShape2Points);
             deleteObjectViaGUIFromSidebar();
-            checkNotExistObject();
+            checkExistObject('not.exist');
         });
 
         it('Create, lock and delete object via "Shift+Delete" shortcuts', () => {
@@ -112,7 +107,7 @@ context('Delete unlock/lock object', () => {
             lockObject();
             checkFailDeleteLockObject('{del}');
             deleteObjectViaShortcut('{shift}{del}', 'lock');
-            checkNotExistObject();
+            checkExistObject('not.exist');
         });
 
         it('Create, lock and delete object via GUI from sidebar', () => {
@@ -120,7 +115,7 @@ context('Delete unlock/lock object', () => {
             lockObject();
             deleteObjectViaGUIFromSidebar();
             actionOnConfirmWindow('OK');
-            checkNotExistObject();
+            checkExistObject('not.exist');
         });
 
         it('Create, lock and cancel delete object via GUI from object', () => {
@@ -128,7 +123,7 @@ context('Delete unlock/lock object', () => {
             lockObject();
             deleteObjectViaGUIFromObject();
             actionOnConfirmWindow('Cancel');
-            checkExistObject();
+            checkExistObject('exist');
         });
     });
 });

--- a/tests/cypress/integration/actions_tasks_objects/case_24_delete_unlock_lock_object.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_24_delete_unlock_lock_object.js
@@ -1,0 +1,87 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName, labelName } from '../../support/const';
+
+context('Delete unlock/lock object', () => {
+    const caseId = '24';
+
+    const createRectangleShape2Points = {
+        points: 'By 2 Points',
+        type: 'Shape',
+        labelName: labelName,
+        firstX: 100,
+        firstY: 100,
+        secondX: 300,
+        secondY: 300,
+    };
+
+    function lockObject() {
+        cy.get('div.cvat-objects-sidebar-state-item').within(() => {
+            cy.get('.cvat-object-item-button-lock').click();
+        });
+    };
+
+    function deleteObjectViaShortcut(shortcut) {
+        cy.get('.cvat-canvas-container')
+            .trigger('mousemove', createRectangleShape2Points.secondX - 10, createRectangleShape2Points.secondY - 10) // activate shape
+            .get('body')
+            .type(shortcut);
+    };
+
+    function deleteObjectViaGUI() {
+        cy.get('div.cvat-objects-sidebar-state-item').within(() => {
+            cy.get('i.ant-dropdown-trigger').click();
+        });
+        cy.get('ul.cvat-object-item-menu').within(() => {
+            cy.contains('Remove').click();
+        });
+    };
+
+    function confirmationToDelete() {
+        cy.get('.ant-modal-confirm').within(() => {
+            cy.contains('OK').click();
+        });
+    };
+
+    function checkExistObject() {
+        cy.get('rect.cvat_canvas_shape').should('not.exist');
+        cy.get('div.cvat-objects-sidebar-state-item').should('not.exist');
+    };
+
+    before(() => {
+        cy.openTaskJob(taskName);
+    });
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Create and delete object via "Delete" shortcut', () => {
+            cy.createRectangle(createRectangleShape2Points);
+            deleteObjectViaShortcut('{del}');
+            checkExistObject();
+        });
+
+        it('Create and delete object via GUI', () => {
+            cy.createRectangle(createRectangleShape2Points);
+            deleteObjectViaGUI();
+            checkExistObject();
+        });
+
+        it('Create, lock and delete object via "Shift+Delete" shortcuts', () => {
+            cy.createRectangle(createRectangleShape2Points);
+            lockObject();
+            deleteObjectViaShortcut('{shift}{del}');
+            checkExistObject();
+        });
+
+        it('Create, lock and delete object via GUI', () => {
+            cy.createRectangle(createRectangleShape2Points);
+            lockObject();
+            deleteObjectViaGUI();
+            confirmationToDelete();
+            checkExistObject();
+        });
+    });
+});


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

Cypress test. Delete unlock and lock object.
Add cssSelectors for elements.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
