### PR TITLE
Fix cypress test case 23.

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_23_canvas_grid_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_23_canvas_grid_feature.js
@@ -12,6 +12,14 @@ context('Canvas grid feature', () => {
     const gridColor = 'Black';
     const gridOpacity = 80;
 
+    function generateString(countPointsToMove) {
+        let action = '';
+        for (let i = 0; i < countPointsToMove; i++) {
+            action += '{leftarrow}';
+        }
+        return action;
+    }
+
     before(() => {
         cy.openTaskJob(taskName);
     });
@@ -37,9 +45,7 @@ context('Canvas grid feature', () => {
         });
         it('Set "Grid opacity" to 80%.', () => {
             cy.get('.cvat-player-settings-grid-opacity-input').within(() => {
-                for (let i = 0; i < 20; i++) {
-                    cy.get('[role="slider"]').type('{leftarrow}'); // Moving the slider to the left up to 80.
-                }
+                cy.get('[role="slider"]').type(generateString(20)); // Moving the slider to the left up to 80.
                 cy.get('[role="slider"]').should('have.attr', 'aria-valuenow', gridOpacity);
             });
         });

--- a/tests/cypress/integration/actions_tasks_objects/case_23_canvas_grid_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_23_canvas_grid_feature.js
@@ -10,7 +10,7 @@ context('Canvas grid feature', () => {
     const caseId = '23';
     const settingsGridSize = 50;
     const gridColor = 'Black';
-    const gridOpacity = 49;
+    const gridOpacity = 80;
 
     before(() => {
         cy.openTaskJob(taskName);
@@ -35,14 +35,15 @@ context('Canvas grid feature', () => {
                 .contains(new RegExp(`^${gridColor}$`, 'g'))
                 .click();
         });
-        it('Set "Grid opacity" to 49%.', () => {
-            cy.get('.cvat-player-settings-grid-opacity-input')
-                .click()
-                .within(() => {
-                    cy.get('[role="slider"]').should('have.attr', 'aria-valuenow', gridOpacity);
-                });
+        it('Set "Grid opacity" to 80%.', () => {
+            cy.get('.cvat-player-settings-grid-opacity-input').within(() => {
+                for (let i = 0; i < 20; i++) {
+                    cy.get('[role="slider"]').type('{leftarrow}'); // Moving the slider to the left up to 80.
+                }
+                cy.get('[role="slider"]').should('have.attr', 'aria-valuenow', gridOpacity);
+            });
         });
-        it('Canvas has grid drawn, it is black, cells are 50x50px and it has 49% opacity.', () => {
+        it('Canvas has grid drawn, it is black, cells are 50x50px and it has 80% opacity.', () => {
             cy.get('#cvat_canvas_grid')
                 .should('be.visible') // expected <svg#cvat_canvas_grid> to be visible
                 .within(() => {
@@ -53,7 +54,7 @@ context('Canvas grid feature', () => {
                             'have.attr',
                             'style',
                             `stroke: ${gridColor.toLowerCase()}; opacity: ${gridOpacity / 100};`,
-                        ); // expected to have attribute style with the value stroke: black; opacity: 0.49;
+                        ); // expected to have attribute style with the value stroke: black; opacity: 0.8;
                 });
         });
     });


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Test execution error in travis-ci via Firefox browser.
By default, Cypress clicks on the object in the center. Locally in Chrome and Firefox, this value is 49% on the slider. But in Travis-ci in Firefox, this value is 50%, so checking the value failed with an error. Reworked the test for moving the slider 20 points to the left, which is 80%.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
