### PR TITLE
Cypress test. Login to task if logout from task.

### DIFF
--- a/cvat-ui/package-lock.json
+++ b/cvat-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/task-page/details.tsx
+++ b/cvat-ui/src/components/task-page/details.tsx
@@ -297,7 +297,7 @@ export default class DetailsComponent extends React.PureComponent<Props, State> 
         return (
             <div className='cvat-task-details'>
                 <Row justify='start' align='middle'>
-                    <Col>{this.renderTaskName()}</Col>
+                    <Col className='cvat-task-details-task-name'>{this.renderTaskName()}</Col>
                 </Row>
                 <Row justify='space-between' align='top'>
                     <Col md={8} lg={7} xl={7} xxl={6}>

--- a/tests/cypress/integration/actions_users/pr_2527_login_to_task_if_logout_from_task.js
+++ b/tests/cypress/integration/actions_users/pr_2527_login_to_task_if_logout_from_task.js
@@ -8,39 +8,55 @@ import { taskName } from '../../support/const';
 
 context('Login to task if logout from task', () => {
     const prId = '2527';
-    let idTask;
-
-    function loginToTask(username = Cypress.env('user'), password = Cypress.env('password')) {
-        cy.get('[placeholder="Username"]').type(username);
-        cy.get('[placeholder="Password"]').type(password);
-        cy.get('[type="submit"]').click();
-        cy.url()
-            .should('include', `/tasks/${idTask}`)
-            .and('not.include', '/auth/login/');
-    }
-
-    function logoutFromTask(username = Cypress.env('user')) {
-        cy.get('.cvat-right-header').within(() => {
-            cy.get('.cvat-header-menu-dropdown').should('have.text', username).trigger('mouseover', { which: 1 });
-        });
-        cy.get('span[aria-label="logout"]').click();
-        cy.url().should('include', `/auth/login/?next=/tasks/${idTask}`);
-    }
+    let taskId;
 
     before(() => {
         cy.openTask(taskName);
 
         // get id task
         cy.url().then((link) => {
-            idTask = Number(link.split('/').slice(-1)[0]);
+            taskId = Number(link.split('/').slice(-1)[0]);
         });
     });
 
     describe(`Testing pr "${prId}"`, () => {
-        it('Logout and login', () => {
-            logoutFromTask();
-            loginToTask();
-            cy.contains('.cvat-task-details-task-name', `${taskName}`).should('exist');
+        it('Logout and login via GUI', () => {
+            // logout from task
+            cy.get('.cvat-right-header').within(() => {
+                cy.get('.cvat-header-menu-dropdown').should('have.text', Cypress.env('user')).trigger('mouseover', { which: 1 });
+            });
+            cy.get('span[aria-label="logout"]').click();
+            cy.url().should('include', `/auth/login/?next=/tasks/${taskId}`);
+
+            // login to task
+            cy.get('[placeholder="Username"]').type(Cypress.env('user'));
+            cy.get('[placeholder="Password"]').type(Cypress.env('password'));
+            cy.get('[type="submit"]').click();
+            cy.url()
+                .should('include', `/tasks/${taskId}`)
+                .and('not.include', '/auth/login/');
+            cy.contains('.cvat-task-details-task-name', `${taskName}`).should('be.visible');
+        });
+
+        it('Logout and login via token', () => {
+            cy.logout();
+
+            // get token and login to task
+            cy.request({
+                method: 'POST',
+                url: '/api/v1/auth/login',
+                body: {
+                    username: Cypress.env('user'),
+                    email: Cypress.env('email'),
+                    password: Cypress.env('password'),
+                },
+            }).then(async (responce) => {
+                responce = await responce['headers']['set-cookie'];
+                const csrfToken = responce[0].match(/csrftoken=\w+/)[0].replace('csrftoken=', '');
+                const sessionId = responce[1].match(/sessionid=\w+/)[0].replace('sessionid=', '');
+                cy.visit(`/login-with-token/${sessionId}/${csrfToken}?next=/tasks/${taskId}`)
+                cy.contains('.cvat-task-details-task-name', `${taskName}`).should('be.visible');
+            });
         });
     });
 });

--- a/tests/cypress/integration/actions_users/pr_2527_login_to_task_if_logout_from_task.js
+++ b/tests/cypress/integration/actions_users/pr_2527_login_to_task_if_logout_from_task.js
@@ -1,0 +1,46 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName } from '../../support/const';
+
+context('Login to task if logout from task', () => {
+    const prId = '2527';
+    let idTask;
+
+    function loginToTask(username = Cypress.env('user'), password = Cypress.env('password')) {
+        cy.get('[placeholder="Username"]').type(username);
+        cy.get('[placeholder="Password"]').type(password);
+        cy.get('[type="submit"]').click();
+        cy.url()
+            .should('include', `/tasks/${idTask}`)
+            .and('not.include', '/auth/login/');
+    }
+
+    function logoutFromTask(username = Cypress.env('user')) {
+        cy.get('.cvat-right-header').within(() => {
+            cy.get('.cvat-header-menu-dropdown').should('have.text', username).trigger('mouseover', { which: 1 });
+        });
+        cy.get('span[aria-label="logout"]').click();
+        cy.url().should('include', `/auth/login/?next=/tasks/${idTask}`);
+    }
+
+    before(() => {
+        cy.openTask(taskName);
+
+        // get id task
+        cy.url().then((link) => {
+            idTask = Number(link.split('/').slice(-1)[0]);
+        });
+    });
+
+    describe(`Testing pr "${prId}"`, () => {
+        it('Logout and login', () => {
+            logoutFromTask();
+            loginToTask();
+            cy.contains('.cvat-task-details-task-name', `${taskName}`).should('exist');
+        });
+    });
+});


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

Cypress test. Login to task if logout from task.
Add cssSelector for element.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
