### PR TITLE
Wrong parametrization of the rqscheduler instance

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -43,7 +43,7 @@ numprocs=1
 
 [program:rqscheduler]
 command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic \
-    "/usr/bin/python3 /usr/local/bin/rqscheduler --host redis -i 30"
+    "/usr/bin/python3 /usr/local/bin/rqscheduler --host %(ENV_CVAT_REDIS_HOST)s -i 30"
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=1
 


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

Closes #2543 

### Motivation and context
Before the change, rqscheduler was initalized with hardcoded "redis" value as a host - instead of using the ENV_CVAT_REDIS_HOST env variable. Due to this error there was no possibility to change the name of the container with redis. The problem appeared when CVAT was installed on kubernetes pod - where the suggested host for accessing containers within the same pod is localhost. Lack of possibility to change this address led to delays in starting CVAT pod - as the kubernetes needs some time to register the "redis" name - while if rqscheduler uses localhost as an address of "redis" connection is made quickly.

### How has this been tested?
I've tested it by running the CVAT deployment on kubernetes. After correction there were no problems with accessing the "redis" container since the start of the CVAT container.


### Checklist
- [X] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [X] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
