### PR TITLE
Cypress test. Always show object details feature.

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_33_always_show_object_details_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_33_always_show_object_details_feature.js
@@ -8,7 +8,7 @@ import { taskName, labelName } from '../../support/const';
 
 context('Always show object details feature', () => {
     const caseId = '33';
-    const firstRectangleShape2Points = {
+    const rectangleShape2Points = {
         points: 'By 2 Points',
         type: 'Shape',
         labelName: labelName,
@@ -17,7 +17,7 @@ context('Always show object details feature', () => {
         secondX: 500,
         secondY: 200,
     };
-    const createPolygonTrack = {
+    const polygonTrack = {
         reDraw: false,
         type: 'Track',
         labelName: labelName,
@@ -29,39 +29,11 @@ context('Always show object details feature', () => {
         complete: true,
         numberOfPoints: null,
     };
-    const createPolylinesShape = {
-        type: 'Shape',
-        labelName: labelName,
-        pointsMap: [
-            { x: 400, y: 400 },
-            { x: 450, y: 450 },
-            { x: 500, y: 500 },
-        ],
-        complete: true,
-        numberOfPoints: null,
-    };
-    const createPointsShape = {
-        type: 'Shape',
-        labelName: labelName,
-        pointsMap: [{ x: 400, y: 550 }],
-        complete: true,
-        numberOfPoints: null,
-    };
-    const createCuboidTrack2Points = {
-        points: 'From rectangle',
-        type: 'Track',
-        labelName: labelName,
-        firstX: 400,
-        firstY: 650,
-        secondX: 600,
-        secondY: 750,
-    };
 
-    function checkShowDetails(...stateDetails) {
+    function checkShowDetails(stateFirstDetails, stateSecondDetails) {
         cy.get('#cvat_canvas_text_content').within(() => {
-            stateDetails.forEach(function (value, index) {
-                cy.contains(`${labelName} ${index + 1}`).should(value);
-            });
+            cy.contains(`${labelName} 1`).should(stateFirstDetails);
+            cy.contains(`${labelName} 2`).should(stateSecondDetails);
         });
     }
 
@@ -69,31 +41,28 @@ context('Always show object details feature', () => {
         cy.openTaskJob(taskName);
 
         // create objects
-        cy.createRectangle(firstRectangleShape2Points);
-        cy.createPolygon(createPolygonTrack);
-        cy.createPolyline(createPolylinesShape);
-        cy.createPoint(createPointsShape);
-        cy.createCuboid(createCuboidTrack2Points);
+        cy.createRectangle(rectangleShape2Points);
+        cy.createPolygon(polygonTrack);
     });
 
     describe(`Testing case "${caseId}"`, () => {
         it('Show details only on activated object', () => {
             // deactivate objects
             cy.get('body').click();
-            checkShowDetails('not.exist', 'not.exist', 'not.exist', 'not.exist', 'not.exist');
+            checkShowDetails('not.exist', 'not.exist');
 
             // activate first object
             cy.get('#cvat_canvas_shape_1')
                 .should('not.have.class', 'cvat_canvas_shape_activated')
                 .trigger('mousemove')
                 .should('have.class', 'cvat_canvas_shape_activated');
-            checkShowDetails('be.visible', 'not.exist', 'not.exist', 'not.exist', 'not.exist');
+            checkShowDetails('be.visible', 'not.exist');
         });
 
         it('Show details all object', () => {
             // deactivate objects
             cy.get('body').click();
-            checkShowDetails('not.exist', 'not.exist', 'not.exist', 'not.exist', 'not.exist');
+            checkShowDetails('not.exist', 'not.exist');
 
             // set checkbox show text always
             cy.openSettings();
@@ -104,7 +73,7 @@ context('Always show object details feature', () => {
                 });
             });
             cy.closeSettings();
-            checkShowDetails('be.visible', 'be.visible', 'be.visible', 'be.visible', 'be.visible');
+            checkShowDetails('be.visible', 'be.visible');
         });
     });
 });

--- a/tests/cypress/integration/actions_tasks_objects/case_33_always_show_object_details_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_33_always_show_object_details_feature.js
@@ -1,0 +1,110 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName, labelName } from '../../support/const';
+
+context('Always show object details feature', () => {
+    const caseId = '33';
+    const firstRectangleShape2Points = {
+        points: 'By 2 Points',
+        type: 'Shape',
+        labelName: labelName,
+        firstX: 400,
+        firstY: 100,
+        secondX: 500,
+        secondY: 200,
+    };
+    const createPolygonTrack = {
+        reDraw: false,
+        type: 'Track',
+        labelName: labelName,
+        pointsMap: [
+            { x: 400, y: 300 },
+            { x: 500, y: 300 },
+            { x: 450, y: 350 },
+        ],
+        complete: true,
+        numberOfPoints: null,
+    };
+    const createPolylinesShape = {
+        type: 'Shape',
+        labelName: labelName,
+        pointsMap: [
+            { x: 400, y: 400 },
+            { x: 450, y: 450 },
+            { x: 500, y: 500 },
+        ],
+        complete: true,
+        numberOfPoints: null,
+    };
+    const createPointsShape = {
+        type: 'Shape',
+        labelName: labelName,
+        pointsMap: [{ x: 400, y: 550 }],
+        complete: true,
+        numberOfPoints: null,
+    };
+    const createCuboidTrack2Points = {
+        points: 'From rectangle',
+        type: 'Track',
+        labelName: labelName,
+        firstX: 400,
+        firstY: 650,
+        secondX: 600,
+        secondY: 750,
+    };
+
+    function checkShowDetails(...stateDetails) {
+        cy.get('#cvat_canvas_text_content').within(() => {
+            stateDetails.forEach(function (value, index) {
+                cy.contains(`${labelName} ${index + 1}`).should(value);
+            });
+        });
+    }
+
+    before(() => {
+        cy.openTaskJob(taskName);
+
+        // create objects
+        cy.createRectangle(firstRectangleShape2Points);
+        cy.createPolygon(createPolygonTrack);
+        cy.createPolyline(createPolylinesShape);
+        cy.createPoint(createPointsShape);
+        cy.createCuboid(createCuboidTrack2Points);
+    });
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Show details only on activated object', () => {
+            // deactivate objects
+            cy.get('body').click();
+            checkShowDetails('not.exist', 'not.exist', 'not.exist', 'not.exist', 'not.exist');
+
+            // activate first object
+            cy.get('#cvat_canvas_shape_1')
+                .should('not.have.class', 'cvat_canvas_shape_activated')
+                .trigger('mousemove')
+                .should('have.class', 'cvat_canvas_shape_activated');
+            checkShowDetails('be.visible', 'not.exist', 'not.exist', 'not.exist', 'not.exist');
+        });
+
+        it('Show details all object', () => {
+            // deactivate objects
+            cy.get('body').click();
+            checkShowDetails('not.exist', 'not.exist', 'not.exist', 'not.exist', 'not.exist');
+
+            // set checkbox show text always
+            cy.openSettings();
+            cy.get('.cvat-settings-modal').within(() => {
+                cy.contains('Workspace').click();
+                cy.get('.cvat-workspace-settings-show-text-always').within(() => {
+                    cy.get('[type="checkbox"]').check();
+                });
+            });
+            cy.closeSettings();
+            checkShowDetails('be.visible', 'be.visible', 'be.visible', 'be.visible', 'be.visible');
+        });
+    });
+});

--- a/tests/cypress/integration/actions_tasks_objects/case_36_always_show_object_details_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_36_always_show_object_details_feature.js
@@ -7,7 +7,7 @@
 import { taskName, labelName } from '../../support/const';
 
 context('Always show object details feature', () => {
-    const caseId = '33';
+    const caseId = '36';
     const rectangleShape2Points = {
         points: 'By 2 Points',
         type: 'Shape',


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

Cypress test. Always show object details feature.

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
