### PR TITLE
Cypress test. Search task feature.

### DIFF
--- a/cvat-ui/src/components/tasks-page/top-bar.tsx
+++ b/cvat-ui/src/components/tasks-page/top-bar.tsx
@@ -25,7 +25,13 @@ export default function TopBarComponent(props: VisibleTopBarProps): JSX.Element 
             <Row justify='center' align='middle'>
                 <Col md={11} lg={9} xl={8} xxl={7}>
                     <Text className='cvat-title'>Tasks</Text>
-                    <Input.Search defaultValue={searchValue} onSearch={onSearch} size='large' placeholder='Search' />
+                    <Input.Search
+                        className='cvat-task-page-search-task'
+                        defaultValue={searchValue}
+                        onSearch={onSearch}
+                        size='large'
+                        placeholder='Search'
+                    />
                 </Col>
                 <Col md={{ span: 11 }} lg={{ span: 9 }} xl={{ span: 8 }} xxl={{ span: 7 }}>
                     <Button

--- a/tests/cypress/integration/actions_tasks_objects/case_35_search_task_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_35_search_task_feature.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName } from '../../support/const';
+
+context('Check if the image is scaled and then fitted', () => {
+    const caseId = '35';
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Type to task search field full name task, part of the task name. The task should exist.', () => {
+            cy.server().route('GET', '/api/v1/tasks**').as('searchTask');
+            cy.get('.cvat-task-page-search-task').type(`${taskName.substring(0, 3)}{Enter}`);
+            cy.wait('@searchTask').its('status').should('equal', 200);
+        });
+    });
+});

--- a/tests/cypress/integration/actions_tasks_objects/case_35_search_task_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_35_search_task_feature.js
@@ -9,19 +9,21 @@ import { taskName } from '../../support/const';
 context('Search task feature.', () => {
     const caseId = '35';
 
-    describe(`Testing case "${caseId}"`, () => {
-        it('Type to task search field full name task, part of the task name. The task should exist.', () => {
-            cy.server().route('GET', '/api/v1/tasks**').as('searchTask');
-            cy.get('.cvat-task-page-search-task').type(`${taskName.substring(0, 3)}{Enter}`);
-            cy.wait('@searchTask').its('status').should('equal', 200);
-            cy.contains('.cvat-item-task-name', taskName).should('exist');
-        });
+    function searchTask(option, result) {
+        cy.server().route('GET', '/api/v1/tasks**').as('searchTask');
+        cy.get('.cvat-task-page-search-task').find('[placeholder="Search"]').clear().type(`${option}{Enter}`);
+        cy.wait('@searchTask').its('status').should('equal', 200);
+        cy.contains('.cvat-item-task-name', taskName).should(result);
+    }
 
-        it('Type to task search field any another text does not contain the name of the task. The task should not exist.', () => {
-            cy.server().route('GET', '/api/v1/tasks**').as('searchTask');
-            cy.get('.cvat-task-page-search-task').type('121212{Enter}');
-            cy.wait('@searchTask').its('status').should('equal', 200);
-            cy.contains('.cvat-item-task-name', taskName).should('not.exist');
+    describe(`Testing case "${caseId}"`, () => {
+        it('Type to task search some field and check result.', () => {
+            searchTask(`${taskName.substring(0, 3)}`, 'exist');
+            searchTask('121212', 'not.exist');
+            searchTask(`owner: ${Cypress.env('user')}`, 'exist');
+            searchTask('mode: annotation', 'exist');
+            searchTask('status: annotation', 'exist');
+            searchTask(`mode: interpolation AND owner: ${Cypress.env('user')}`, 'not.exist');
         });
     });
 });

--- a/tests/cypress/integration/actions_tasks_objects/case_35_search_task_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_35_search_task_feature.js
@@ -6,7 +6,7 @@
 
 import { taskName } from '../../support/const';
 
-context('Check if the image is scaled and then fitted', () => {
+context('Search task feature.', () => {
     const caseId = '35';
 
     describe(`Testing case "${caseId}"`, () => {

--- a/tests/cypress/integration/actions_tasks_objects/case_35_search_task_feature.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_35_search_task_feature.js
@@ -14,6 +14,14 @@ context('Check if the image is scaled and then fitted', () => {
             cy.server().route('GET', '/api/v1/tasks**').as('searchTask');
             cy.get('.cvat-task-page-search-task').type(`${taskName.substring(0, 3)}{Enter}`);
             cy.wait('@searchTask').its('status').should('equal', 200);
+            cy.contains('.cvat-item-task-name', taskName).should('exist');
+        });
+
+        it('Type to task search field any another text does not contain the name of the task. The task should not exist.', () => {
+            cy.server().route('GET', '/api/v1/tasks**').as('searchTask');
+            cy.get('.cvat-task-page-search-task').type('121212{Enter}');
+            cy.wait('@searchTask').its('status').should('equal', 200);
+            cy.contains('.cvat-item-task-name', taskName).should('not.exist');
         });
     });
 });


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Cypress test. Search task feature.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
