### PR TITLE
Fix migration error in CRON type of CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - if [[ $TRAVIS_EVENT_TYPE == "cron" || $TRAVIS_BRANCH == "dkru/use-wait-for-it-sh" ]];
     then
     docker-compose -f docker-compose.yml -f ./tests/docker-compose.email.yml up -d --build;
-    ./wait-for-it.sh localhost:8080/auth/login -t 0 -- docker exec -it cvat bash -ic "echo \"from django.contrib.auth.models import User; User.objects.create_superuser('${DJANGO_SU_NAME}', '${DJANGO_SU_EMAIL}', '${DJANGO_SU_PASSWORD}')\" | python3 ~/manage.py shell";
+    ./wait-for-it.sh localhost:8080/api/v1/server/about -t 0 -- docker exec -it cvat bash -ic "echo \"from django.contrib.auth.models import User; User.objects.create_superuser('${DJANGO_SU_NAME}', '${DJANGO_SU_EMAIL}', '${DJANGO_SU_PASSWORD}')\" | python3 ~/manage.py shell";
     cd ./tests && npm install && npm run cypress:run:firefox; exit $?;
     fi;
   - docker-compose -f docker-compose.yml -f docker-compose.ci.yml build

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   - chmod a+rwx ${HOST_COVERAGE_DATA_DIR}
 
 script:
-  - if [[ $TRAVIS_EVENT_TYPE == "cron" || $TRAVIS_BRANCH == "dkru/use-wait-for-it-sh" ]];
+  - if [[ $TRAVIS_EVENT_TYPE == "cron" && $TRAVIS_BRANCH == "develop" ]];
     then
     docker-compose -f docker-compose.yml -f ./tests/docker-compose.email.yml up -d --build;
     bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${API_ABOUT_PAGE})" != "401" ]]; do sleep 5; done';

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,10 @@ before_script:
   - chmod a+rwx ${HOST_COVERAGE_DATA_DIR}
 
 script:
-  - if [[ $TRAVIS_EVENT_TYPE == "cron" && $TRAVIS_BRANCH == "develop" ]];
+  - if [[ $TRAVIS_EVENT_TYPE == "cron" || $TRAVIS_BRANCH == "dkru/use-wait-for-it-sh" ]];
     then
     docker-compose -f docker-compose.yml -f ./tests/docker-compose.email.yml up -d --build;
-    docker exec -it cvat bash -ic 'python3 ~/manage.py migrate';
-    docker exec -it cvat bash -ic "echo \"from django.contrib.auth.models import User; User.objects.create_superuser('${DJANGO_SU_NAME}', '${DJANGO_SU_EMAIL}', '${DJANGO_SU_PASSWORD}')\" | python3 ~/manage.py shell";
+    ./wait-for-it.sh localhost:8080/auth/login -t 0 -- docker exec -it cvat bash -ic "echo \"from django.contrib.auth.models import User; User.objects.create_superuser('${DJANGO_SU_NAME}', '${DJANGO_SU_EMAIL}', '${DJANGO_SU_PASSWORD}')\" | python3 ~/manage.py shell";
     cd ./tests && npm install && npm run cypress:run:firefox; exit $?;
     fi;
   - docker-compose -f docker-compose.yml -f docker-compose.ci.yml build

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     DJANGO_SU_EMAIL="admin@localhost.company"
     DJANGO_SU_PASSWORD="12qwaszx"
     NODE_VERSION="12"
+    API_ABOUT_PAGE="localhost:8080/api/v1/server/about"
 
 before_install:
   - nvm install ${NODE_VERSION}
@@ -34,7 +35,8 @@ script:
   - if [[ $TRAVIS_EVENT_TYPE == "cron" || $TRAVIS_BRANCH == "dkru/use-wait-for-it-sh" ]];
     then
     docker-compose -f docker-compose.yml -f ./tests/docker-compose.email.yml up -d --build;
-    ./wait-for-it.sh localhost:8080/api/v1/server/about -t 0 -- docker exec -it cvat bash -ic "echo \"from django.contrib.auth.models import User; User.objects.create_superuser('${DJANGO_SU_NAME}', '${DJANGO_SU_EMAIL}', '${DJANGO_SU_PASSWORD}')\" | python3 ~/manage.py shell";
+    bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${API_ABOUT_PAGE})" != "401" ]]; do sleep 5; done';
+    docker exec -it cvat bash -ic "echo \"from django.contrib.auth.models import User; User.objects.create_superuser('${DJANGO_SU_NAME}', '${DJANGO_SU_EMAIL}', '${DJANGO_SU_PASSWORD}')\" | python3 ~/manage.py shell";
     cd ./tests && npm install && npm run cypress:run:firefox; exit $?;
     fi;
   - docker-compose -f docker-compose.yml -f docker-compose.ci.yml build


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
At the moment, an error is observed in CI in the CRON type when migrating the database. This patch was created to solve it.
Added a command to wait for a response with the status 401 from the page ```localhost:8080/api/v1/server/about```

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
