### PR TITLE
Fix frame preloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Memory consumption for the task creation process (<https://github.com/openvinotoolkit/cvat/pull/2582>)
+- Frame preloading (<https://github.com/openvinotoolkit/cvat/pull/2608>)
 
 ### Security
 

--- a/cvat-data/package-lock.json
+++ b/cvat-data/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-data",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-data/package.json
+++ b/cvat-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-data",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "src/js/cvat-data.js",
   "devDependencies": {

--- a/cvat-data/src/js/cvat-data.js
+++ b/cvat-data/src/js/cvat-data.js
@@ -21,6 +21,7 @@ class FrameProvider {
         this._blocksRanges = [];
         this._blocks = {};
         this._running = false;
+        this._blockSize = blockSize;
         this._blockType = blockType;
         this._currFrame = -1;
         this._requestedBlockDecode = null;


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Frame preloading doesn't work due improperly initialization of `FrameProvider` by this commit https://github.com/openvinotoolkit/cvat/commit/7512fd6883829ff2692ef42a5a41a06f3805da14#diff-44a538d6db30ba4db0034acd80cc53f908c457d6a69cecd55bc9a968c43cb26fL29

### How has this been tested?
Manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
~~- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly~~
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
