### PR TITLE
Fix multiple tests for the Firefox browser

### DIFF
--- a/cvat-ui/src/components/cvat-app.tsx
+++ b/cvat-ui/src/components/cvat-app.tsx
@@ -276,6 +276,7 @@ class CVATApplication extends React.PureComponent<CVATAppProps & RouteComponentP
 
             Modal.warning({
                 title: 'Unsupported platform detected',
+                className: 'cvat-modal-unsupported-platform-warning',
                 content: (
                     <>
                         <Row>

--- a/tests/cypress/integration/actions_tasks_objects/case_15_group_features.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_15_group_features.js
@@ -174,6 +174,11 @@ context('Group features', () => {
             cy.removeAnnotations();
             cy.saveJob();
             cy.reload();
+            if (Cypress.browser.family !== 'chromium') {
+                cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
+                    cy.contains('button', 'OK').click();
+                });
+            }
             cy.get('.cvat-canvas-container').should('exist');
         });
 

--- a/tests/cypress/integration/actions_tasks_objects/case_15_group_features.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_15_group_features.js
@@ -175,9 +175,7 @@ context('Group features', () => {
             cy.saveJob();
             cy.reload();
             if (Cypress.browser.family !== 'chromium') {
-                cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
-                    cy.contains('button', 'OK').click();
-                });
+                cy.closeModalUnsupportedPlatform();
             }
             cy.get('.cvat-canvas-container').should('exist');
         });

--- a/tests/cypress/integration/actions_tasks_objects/case_15_group_features.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_15_group_features.js
@@ -174,9 +174,7 @@ context('Group features', () => {
             cy.removeAnnotations();
             cy.saveJob();
             cy.reload();
-            if (Cypress.browser.family !== 'chromium') {
-                cy.closeModalUnsupportedPlatform();
-            }
+            cy.closeModalUnsupportedPlatform();
             cy.get('.cvat-canvas-container').should('exist');
         });
 

--- a/tests/cypress/integration/actions_users/issue_1810_login_logout.js
+++ b/tests/cypress/integration/actions_users/issue_1810_login_logout.js
@@ -10,19 +10,13 @@ context('When clicking on the Logout button, get the user session closed.', () =
     const issueId = '1810';
     let taskId;
 
-    function closeModal() {
-        if (Cypress.browser.family !== 'chromium') {
-            cy.closeModalUnsupportedPlatform();
-        }
-    }
-
     before(() => {
         cy.visit('auth/login');
     });
 
     describe(`Testing issue "${issueId}"`, () => {
         it('Login', () => {
-            closeModal();
+            cy.closeModalUnsupportedPlatform();
             cy.login();
         });
 
@@ -31,7 +25,7 @@ context('When clicking on the Logout button, get the user session closed.', () =
         });
 
         it('Login and open task', () => {
-            closeModal();
+            cy.closeModalUnsupportedPlatform();
             cy.login();
             cy.openTask(taskName);
             // get id task
@@ -73,7 +67,7 @@ context('When clicking on the Logout button, get the user session closed.', () =
                 const csrfToken = responce[0].match(/csrftoken=\w+/)[0].replace('csrftoken=', '');
                 const sessionId = responce[1].match(/sessionid=\w+/)[0].replace('sessionid=', '');
                 cy.visit(`/login-with-token/${sessionId}/${csrfToken}?next=/tasks/${taskId}`);
-                closeModal();
+                cy.closeModalUnsupportedPlatform();
                 cy.contains('.cvat-task-details-task-name', `${taskName}`).should('be.visible');
             });
         });

--- a/tests/cypress/integration/actions_users/issue_1810_login_logout.js
+++ b/tests/cypress/integration/actions_users/issue_1810_login_logout.js
@@ -16,6 +16,11 @@ context('When clicking on the Logout button, get the user session closed.', () =
 
     describe(`Testing issue "${issueId}"`, () => {
         it('Login', () => {
+            if (Cypress.browser.family !== 'chromium') {
+                cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
+                    cy.contains('button', 'OK').click();
+                });
+            }
             cy.login();
         });
 
@@ -24,6 +29,11 @@ context('When clicking on the Logout button, get the user session closed.', () =
         });
 
         it('Login and open task', () => {
+            if (Cypress.browser.family !== 'chromium') {
+                cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
+                    cy.contains('button', 'OK').click();
+                });
+            }
             cy.login();
             cy.openTask(taskName);
             // get id task
@@ -35,7 +45,9 @@ context('When clicking on the Logout button, get the user session closed.', () =
         it('Logout and login to task via GUI', () => {
             // logout from task
             cy.get('.cvat-right-header').within(() => {
-                cy.get('.cvat-header-menu-dropdown').should('have.text', Cypress.env('user')).trigger('mouseover', { which: 1 });
+                cy.get('.cvat-header-menu-dropdown')
+                    .should('have.text', Cypress.env('user'))
+                    .trigger('mouseover', { which: 1 });
             });
             cy.get('span[aria-label="logout"]').click();
             cy.url().should('include', `/auth/login/?next=/tasks/${taskId}`);
@@ -43,9 +55,7 @@ context('When clicking on the Logout button, get the user session closed.', () =
             cy.get('[placeholder="Username"]').type(Cypress.env('user'));
             cy.get('[placeholder="Password"]').type(Cypress.env('password'));
             cy.get('[type="submit"]').click();
-            cy.url()
-                .should('include', `/tasks/${taskId}`)
-                .and('not.include', '/auth/login/');
+            cy.url().should('include', `/tasks/${taskId}`).and('not.include', '/auth/login/');
             cy.contains('.cvat-task-details-task-name', `${taskName}`).should('be.visible');
         });
 
@@ -64,7 +74,12 @@ context('When clicking on the Logout button, get the user session closed.', () =
                 responce = await responce['headers']['set-cookie'];
                 const csrfToken = responce[0].match(/csrftoken=\w+/)[0].replace('csrftoken=', '');
                 const sessionId = responce[1].match(/sessionid=\w+/)[0].replace('sessionid=', '');
-                cy.visit(`/login-with-token/${sessionId}/${csrfToken}?next=/tasks/${taskId}`)
+                cy.visit(`/login-with-token/${sessionId}/${csrfToken}?next=/tasks/${taskId}`);
+                if (Cypress.browser.family !== 'chromium') {
+                    cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
+                        cy.contains('button', 'OK').click();
+                    });
+                }
                 cy.contains('.cvat-task-details-task-name', `${taskName}`).should('be.visible');
             });
         });

--- a/tests/cypress/integration/actions_users/issue_1810_login_logout.js
+++ b/tests/cypress/integration/actions_users/issue_1810_login_logout.js
@@ -10,17 +10,19 @@ context('When clicking on the Logout button, get the user session closed.', () =
     const issueId = '1810';
     let taskId;
 
+    function closeModal() {
+        if (Cypress.browser.family !== 'chromium') {
+            cy.closeModalUnsupportedPlatform();
+        }
+    }
+
     before(() => {
         cy.visit('auth/login');
     });
 
     describe(`Testing issue "${issueId}"`, () => {
         it('Login', () => {
-            if (Cypress.browser.family !== 'chromium') {
-                cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
-                    cy.contains('button', 'OK').click();
-                });
-            }
+            closeModal();
             cy.login();
         });
 
@@ -29,11 +31,7 @@ context('When clicking on the Logout button, get the user session closed.', () =
         });
 
         it('Login and open task', () => {
-            if (Cypress.browser.family !== 'chromium') {
-                cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
-                    cy.contains('button', 'OK').click();
-                });
-            }
+            closeModal();
             cy.login();
             cy.openTask(taskName);
             // get id task
@@ -75,11 +73,7 @@ context('When clicking on the Logout button, get the user session closed.', () =
                 const csrfToken = responce[0].match(/csrftoken=\w+/)[0].replace('csrftoken=', '');
                 const sessionId = responce[1].match(/sessionid=\w+/)[0].replace('sessionid=', '');
                 cy.visit(`/login-with-token/${sessionId}/${csrfToken}?next=/tasks/${taskId}`);
-                if (Cypress.browser.family !== 'chromium') {
-                    cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
-                        cy.contains('button', 'OK').click();
-                    });
-                }
+                closeModal();
                 cy.contains('.cvat-task-details-task-name', `${taskName}`).should('be.visible');
             });
         });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -592,7 +592,9 @@ Cypress.Commands.add('getObjectIdNumberByLabelName', (labelName) => {
 });
 
 Cypress.Commands.add('closeModalUnsupportedPlatform', () => {
-    cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
-        cy.contains('button', 'OK').click();
-    });
+    if (Cypress.browser.family !== 'chromium') {
+        cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
+            cy.contains('button', 'OK').click();
+        });
+    }
 });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -274,7 +274,6 @@ Cypress.Commands.add('changeWorkspace', (mode, labelName) => {
 });
 
 Cypress.Commands.add('changeLabelAAM', (labelName) => {
-
     cy.get('.cvat-workspace-selector').then((value) => {
         const cvatWorkspaceSelectorValue = value.text();
         if (cvatWorkspaceSelectorValue.includes('Attribute annotation')) {
@@ -420,7 +419,7 @@ Cypress.Commands.add('removeAnnotations', () => {
         cy.contains('Remove annotations').click();
     });
     cy.get('.cvat-modal-confirm-remove-annotation').within(() => {
-        cy.contains('button','Delete').click();
+        cy.contains('button', 'Delete').click();
     });
 });
 
@@ -576,15 +575,24 @@ Cypress.Commands.add('goToPreviousFrame', (expectedFrameNum) => {
 
 Cypress.Commands.add('getObjectIdNumberByLabelName', (labelName) => {
     cy.document().then((doc) => {
-        const stateItemLabelSelectorList = Array.from(doc.querySelectorAll('.cvat-objects-sidebar-state-item-label-selector'));
+        const stateItemLabelSelectorList = Array.from(
+            doc.querySelectorAll('.cvat-objects-sidebar-state-item-label-selector'),
+        );
         for (let i = 0; i < stateItemLabelSelectorList.length; i++) {
             if (stateItemLabelSelectorList[i].textContent === labelName) {
                 cy.get(stateItemLabelSelectorList[i])
                     .parents('.cvat-objects-sidebar-state-item')
-                    .should('have.attr', 'id').then((id) => {
+                    .should('have.attr', 'id')
+                    .then((id) => {
                         return Number(id.match(/\d+$/));
                     });
             }
         }
+    });
+});
+
+Cypress.Commands.add('closeModalUnsupportedPlatform', () => {
+    cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
+        cy.contains('button', 'OK').click();
     });
 });

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -10,9 +10,7 @@ require('cypress-plugin-tab');
 before(() => {
     if (Cypress.browser.family !== 'chromium') {
         cy.visit('/');
-        cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
-            cy.contains('button', 'OK').click();
-        });
+        cy.closeModalUnsupportedPlatform();
     }
 });
 

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -9,9 +9,8 @@ require('@cypress/code-coverage/support');
 before(() => {
     if (Cypress.browser.family !== 'chromium') {
         cy.visit('/');
-        cy.get('.ant-modal-body').within(() => {
-            cy.get('.ant-modal-confirm-title').should('contain', 'Unsupported platform detected');
-            cy.get('.ant-modal-confirm-btns').contains('OK').click();
+        cy.get('.cvat-modal-unsupported-platform-warning').within(() => {
+            cy.contains('button', 'OK').click();
         });
     }
 });

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -10,8 +10,8 @@ require('cypress-plugin-tab');
 before(() => {
     if (Cypress.browser.family !== 'chromium') {
         cy.visit('/');
-        cy.closeModalUnsupportedPlatform();
     }
+    cy.closeModalUnsupportedPlatform();
 });
 
 const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
A warning window appears about an unsupported platform when using cy.visit() or cy.reload()
Adding a css class to minimize the use of ant-* classes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
