### PR TITLE
Cypress test. Rename task feature.

### DIFF
--- a/tests/cypress.json
+++ b/tests/cypress.json
@@ -11,7 +11,7 @@
   },
   "testFiles": [
     "auth_page.js",
-    "actions_tasks_objects/*",
+    "actions_tasks_objects/**/*",
     "actions_users/**/*",
     "actions_projects/**/*",
     "remove_users_tasks_projects.js"

--- a/tests/cypress/integration/actions_tasks_objects/registration_involved/case_39_issue_2572_rename_task.js
+++ b/tests/cypress/integration/actions_tasks_objects/registration_involved/case_39_issue_2572_rename_task.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+context('Rename a task.', () => {
+    const caseId = '39';
+    const labelName = `Case ${caseId}`;
+    const taskName = `New annotation task for ${labelName}`;
+    const attrName = `Attr for ${labelName}`;
+    const textDefaultValue = 'Some default value for type Text';
+    const imagesCount = 1;
+    const imageFileName = `image_${labelName.replace(' ', '_').toLowerCase()}`;
+    const width = 800;
+    const height = 800;
+    const posX = 10;
+    const posY = 10;
+    const color = 'gray';
+    const archiveName = `${imageFileName}.zip`;
+    const archivePath = `cypress/fixtures/${archiveName}`;
+    const imagesFolder = `cypress/fixtures/${imageFileName}`;
+    const directoryToArchive = imagesFolder;
+    const newNaskName = taskName.replace('39', '3339');
+    const secondUserName = 'Case39';
+    const secondUser = {
+        firstName: `Firtstnamerenametask`,
+        lastName: `Lastnamerenametask`,
+        emailAddr: `${secondUserName.toLowerCase()}@local.local`,
+        password: 'Pass!UserCase39',
+    };
+
+    function renameTask(taskName, newValue) {
+        cy.get('.cvat-task-details-task-name').within(() => {
+            cy.get('[aria-label="edit"]').click();
+        });
+        cy.contains('.cvat-text-color', taskName).click().type(newValue);
+    }
+
+    before(() => {
+        cy.visit('auth/login');
+        cy.login();
+        cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, labelName, imagesCount);
+        cy.createZipArchive(directoryToArchive, archivePath);
+        cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, archiveName);
+        cy.openTask(taskName);
+    });
+
+    after(() => {
+        cy.login();
+        cy.getTaskID(newNaskName).then(($taskID) => {
+            cy.deleteTask(newNaskName, $taskID);
+        });
+    });
+
+    describe(`Testing "${labelName}". Issue 2572.`, () => {
+        it('Rename the task. Issue is not reproduce.', () => {
+            renameTask(taskName, '{leftarrow}{leftarrow}33{Enter}');
+            cy.contains('.cvat-task-details-task-name', newNaskName).should('exist');
+            cy.logout();
+        });
+        it('Registration a second user. Rename the task. Status 403 appear.', () => {
+            cy.goToRegisterPage();
+            cy.userRegistration(
+                secondUser.firstName,
+                secondUser.lastName,
+                secondUserName,
+                secondUser.emailAddr,
+                secondUser.password,
+            );
+            cy.openTask(newNaskName);
+            renameTask(newNaskName, '{leftarrow}{leftarrow}3{Enter}');
+            cy.get('.cvat-notification-notice-update-task-failed').should('exist');
+            cy.closeNotification('.cvat-notification-notice-update-task-failed');
+            cy.logout(secondUserName);
+        });
+    });
+});


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Also contains the issue #2572 check.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
