### PR TITLE
Cypress test. Add/delete labels and attributes.

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_41_add_delete_label_attribute.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_41_add_delete_label_attribute.js
@@ -13,15 +13,12 @@ context('Add/delete labels and attributes.', () => {
     before(() => {
         cy.visit('auth/login');
         cy.login();
+        cy.get('#cvat-create-task-button').click();
     });
 
     describe(`Testing "${labelName}"`, () => {
-        it('Go to create task page. Open label constructor.', () => {
-            cy.get('#cvat-create-task-button').click();
-            cy.get('.cvat-constructor-viewer-new-item').click();
-        });
-
         it('Start adding a label. Press Cancel. The label is not created.', () => {
+            cy.get('.cvat-constructor-viewer-new-item').click(); // Open label constructor
             cy.get('[placeholder="Label name"]').type(labelName);
             cy.contains('[type="button"]', 'Cancel').click();
             cy.get('.cvat-constructor-viewer-item').should('not.exist');
@@ -51,7 +48,7 @@ context('Add/delete labels and attributes.', () => {
             cy.get('.cvat-constructor-viewer-item').should('exist');
         });
 
-        it('Start to edit the label. Attribute should be exist. Remove the atrribute. Press Done.', () => {
+        it('Start to edit the label. Attribute should exist. Remove the atrribute. Press Done.', () => {
             cy.get('.cvat-constructor-viewer-item').find('[aria-label="edit"]').click();
             cy.get('.cvat-attribute-inputs-wrapper')
                 .should('exist')
@@ -60,9 +57,7 @@ context('Add/delete labels and attributes.', () => {
                 });
             cy.get('.cvat-attribute-inputs-wrapper').should('not.exist');
             cy.contains('[type="submit"]', 'Done').click();
-        });
-
-        it('Start to edit the created label. Attribute should not be exist. Press Cancel.', () => {
+            // After deleting the attribute and saving the changes, check that the attribute is missing.
             cy.get('.cvat-constructor-viewer-item').find('[aria-label="edit"]').click();
             cy.get('.cvat-attribute-inputs-wrapper').should('not.exist');
             cy.contains('[type="button"]', 'Cancel').click();

--- a/tests/cypress/integration/actions_tasks_objects/case_41_add_delete_label_attribute.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_41_add_delete_label_attribute.js
@@ -1,0 +1,76 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+context('Add/delete labels and attributes.', () => {
+    const caseId = '41';
+    const labelName = `Case ${caseId}`;
+    const attrName = `Attr for ${labelName}`;
+    const textDefaultValue = 'Some default value for type Text';
+
+    before(() => {
+        cy.visit('auth/login');
+        cy.login();
+    });
+
+    describe(`Testing "${labelName}"`, () => {
+        it('Go to create task page. Open label constructor.', () => {
+            cy.get('#cvat-create-task-button').click();
+            cy.get('.cvat-constructor-viewer-new-item').click();
+        });
+
+        it('Start adding a label. Press Cancel. The label is not created.', () => {
+            cy.get('[placeholder="Label name"]').type(labelName);
+            cy.contains('[type="button"]', 'Cancel').click();
+            cy.get('.cvat-constructor-viewer-item').should('not.exist');
+        });
+
+        it('Start adding a label. Start adding an attribute. Press Cancel. The label is not created.', () => {
+            cy.get('.cvat-constructor-viewer-new-item').click();
+            cy.get('[placeholder="Label name"]').type(labelName);
+            cy.get('.cvat-new-attribute-button').click();
+            cy.get('.cvat-attribute-name-input').type(attrName);
+            cy.get('.cvat-attribute-type-input').click();
+            cy.get('.cvat-attribute-type-input-text').click();
+            cy.get('.cvat-attribute-values-input').type(textDefaultValue);
+            cy.contains('[type="button"]', 'Cancel').click();
+            cy.get('.cvat-constructor-viewer-item').should('not.exist');
+        });
+
+        it('Start adding a label. Add an attribute. Press Done. The label should be created.', () => {
+            cy.get('.cvat-constructor-viewer-new-item').click();
+            cy.get('[placeholder="Label name"]').type(labelName);
+            cy.get('.cvat-new-attribute-button').click();
+            cy.get('.cvat-attribute-name-input').type(attrName);
+            cy.get('.cvat-attribute-type-input').click();
+            cy.get('.cvat-attribute-type-input-text').click();
+            cy.get('.cvat-attribute-values-input').type(textDefaultValue);
+            cy.contains('[type="submit"]', 'Done').click();
+            cy.get('.cvat-constructor-viewer-item').should('exist');
+        });
+
+        it('Start to edit the label. Attribute should be exist. Remove the atrribute. Press Done.', () => {
+            cy.get('.cvat-constructor-viewer-item').find('[aria-label="edit"]').click();
+            cy.get('.cvat-attribute-inputs-wrapper')
+                .should('exist')
+                .within(() => {
+                    cy.get('.cvat-delete-attribute-button').click();
+                });
+            cy.get('.cvat-attribute-inputs-wrapper').should('not.exist');
+            cy.contains('[type="submit"]', 'Done').click();
+        });
+
+        it('Start to edit the created label. Attribute should not be exist. Press Cancel.', () => {
+            cy.get('.cvat-constructor-viewer-item').find('[aria-label="edit"]').click();
+            cy.get('.cvat-attribute-inputs-wrapper').should('not.exist');
+            cy.contains('[type="button"]', 'Cancel').click();
+        });
+
+        it('Delete the added label. The label removed.', () => {
+            cy.get('.cvat-constructor-viewer-item').find('[aria-label="close"]').click();
+            cy.get('.cvat-constructor-viewer-item').should('not.exist');
+        });
+    });
+});


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Add Cypress test. Add/delete labels and attributes.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
