### PR TITLE
Cypress test. Creating a label with existing label name.

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_43_create_label_with_existing_label_name.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_43_create_label_with_existing_label_name.js
@@ -1,0 +1,34 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName } from '../../support/const';
+
+context('Creating a label with existing label name.', () => {
+    const caseId = '43';
+    let firstLabelName = '';
+
+    before(() => {
+        cy.openTask(taskName);
+    });
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Try to create a label with existing name. Should not be successful.', () => {
+            // Get the name of the first existing label.
+            cy.get('.cvat-constructor-viewer-item')
+                .first()
+                .then((firstLabel) => {
+                    firstLabelName = firstLabel.text();
+                    // Try to create a label with existing label name
+                    cy.get('.cvat-constructor-viewer-new-item').click();
+                    cy.get('[placeholder="Label name"]').type(firstLabelName);
+                    cy.contains('[type="submit"]', 'Done').click();
+                });
+            cy.get('.cvat-notification-notice-update-task-failed')
+                .should('exist')
+                .and('contain.text', 'label names must be unique');
+        });
+    });
+});


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Add cypress test. Creating a label with existing label name.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
