### PR TITLE
Cypress test. Changing a default value for an attribute.

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_44_changing_default_value_for_attribute.js
@@ -1,0 +1,78 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName } from '../../support/const';
+
+context('Changing a default value for an attribute.', () => {
+    const caseId = '44';
+    const additionalLabel = `Case ${caseId}`;
+    const additionalAttrsLabel = [
+        { additionalAttrName: 'type', additionalValue: '', typeAttribute: 'Text' },
+        { additionalAttrName: 'shape', additionalValue: 'False', typeAttribute: 'Checkbox' },
+    ];
+    const rectangleShape2Points = {
+        points: 'By 2 Points',
+        type: 'Shape',
+        labelName: additionalLabel,
+        firstX: 400,
+        firstY: 100,
+        secondX: 500,
+        secondY: 200,
+    };
+    const newTextValue = `${additionalLabel} text`;
+    const newCheckboxValue = 'True';
+    let wrapperId = [];
+
+    before(() => {
+        cy.openTask(taskName);
+    });
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Add a label, add text (leave it’s value empty by default) & checkbox attributes.', () => {
+            cy.server().route('PATCH', '/api/v1/tasks/**').as('patchTask');
+            cy.server().route('GET', '/api/v1/tasks**').as('getTask');
+            cy.addNewLabel(additionalLabel, additionalAttrsLabel);
+            cy.wait('@patchTask').its('status').should('equal', 200);
+            cy.wait('@getTask').its('status').should('equal', 200);
+        });
+
+        it('Open label editor. Change default values for text & checkbox attributes, press Done.', () => {
+            cy.server().route('PATCH', '/api/v1/tasks/**').as('patchTask');
+            cy.get('.cvat-constructor-viewer').within(() => {
+                cy.contains(new RegExp(`^${additionalLabel}$`))
+                    .parents('.cvat-constructor-viewer-item')
+                    .find('[aria-label="edit"]')
+                    .click({ force: true });
+            });
+            cy.get('.cvat-label-constructor-updater').within(() => {
+                cy.get('.cvat-attribute-inputs-wrapper').then((wrapper) => {
+                    for (let i = 0; i < wrapper.length; i++) {
+                        wrapperId.push(wrapper[i].getAttribute('cvat-attribute-id'));
+                    }
+                    const minId = Math.min(...wrapperId);
+                    const maxId = Math.max(...wrapperId);
+                    cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
+                    cy.task('log', `minId: ${minId}`);
+                    cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click().wait(500); // Wait for the dropdown menu to transition.
+                    cy.task('log', `maxId: ${maxId}`);
+                });
+            });
+            cy.get('.ant-select-dropdown').within(() => {
+                cy.contains(new RegExp(`^${newCheckboxValue}$`)).click();
+            });
+            cy.contains('[type="submit"]', 'Done').click();
+            cy.wait('@patchTask').its('status').should('equal', 200);
+        });
+
+        it('Open a job, create an object. Attribute values are correct.', () => {
+            cy.openJob();
+            cy.createRectangle(rectangleShape2Points);
+            cy.get('#cvat_canvas_shape_1').trigger('mousemove');
+            cy.contains(new RegExp(`^type: ${newTextValue}$`)).should('be.visible');
+            cy.contains(new RegExp(`^shape: ${newCheckboxValue.toLowerCase()}$`)).should('be.visible');
+        });
+    });
+});

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -339,7 +339,11 @@ Cypress.Commands.add('updateAttributes', (multiAttrParams) => {
 
         if (multiAttrParams.typeAttribute === 'Text' || multiAttrParams.typeAttribute === 'Number') {
             cy.get(`[cvat-attribute-id="${minId}"]`).within(() => {
-                cy.get('.cvat-attribute-values-input').type(multiAttrParams.additionalValue);
+                if (multiAttrParams.additionalValue !== '') {
+                    cy.get('.cvat-attribute-values-input').type(multiAttrParams.additionalValue);
+                } else {
+                    cy.get('.cvat-attribute-values-input').clear();
+                }
             });
         } else if (multiAttrParams.typeAttribute === 'Radio') {
             cy.get(`[cvat-attribute-id="${minId}"]`).within(() => {


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Add Cypress test.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
