### PR TITLE
Fix cypress test "Changing label name via label constructor".

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_42_change_label_name_via_label_constructor.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_42_change_label_name_via_label_constructor.js
@@ -24,7 +24,7 @@ context('Changing a label name via label constructor.', () => {
 
         it('Change label name to any other correct value. Press "Done" button. The label created.', () => {
             cy.get('[placeholder="Label name"]').type(firstLabelName);
-            cy.contains('[type="submit"]', 'Done').click();
+            cy.contains('[type="submit"]', 'Done').click({ force: true });
             cy.get('.cvat-constructor-viewer-item').should('exist').and('have.text', firstLabelName);
         });
 


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
An error occurred in CI when passing the test steps
```
`<button type="submit" class="ant-btn ant-btn-primary ant-tooltip-open" ant-click-animating-without-extra-node="false" style="width: 150px;">...</button>`
This element `<button.ant-btn.ant-btn-primary.ant-tooltip-open>` is not visible because it has CSS property: `position: fixed` and it's being covered by another element:
`<div class="ant-tooltip ant-tooltip-placement-top " style="left: 277px; top: 493px; transform-origin: 50% 46px;">...</div>`
```
Added ```force: true``` when the button is clicked.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
