### PR TITLE
Increase pip default timeout

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,7 @@
 FROM cvat/server
 
-ENV DJANGO_CONFIGURATION=testing
+ENV DJANGO_CONFIGURATION=testing \
+    PIP_DEFAULT_TIMEOUT=1000
 USER root
 
 RUN apt-get update && \


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
To be able to download tensorflow fully before timeout. The full package is 394.8 MB large.

```
#47 24.62   Downloading tensorflow-2.4.0-cp38-cp38-manylinux2010_x86_64.whl (394.8 MB)
#47 69.32 ERROR: Exception:
#47 69.32 Traceback (most recent call last):
#47 69.32   File "/opt/venv/lib/python3.8/site-packages/pip/_vendor/urllib3/response.py", line 425, in _error_catcher
#47 69.32     yield
#47 69.32   File "/opt/venv/lib/python3.8/site-packages/pip/_vendor/urllib3/response.py", line 507, in read
#47 69.32     data = self._fp.read(amt) if not fp_closed else b""
#47 69.32   File "/usr/lib/python3.8/http/client.py", line 458, in read
#47 69.32     n = self.readinto(b)
#47 69.32   File "/usr/lib/python3.8/http/client.py", line 502, in readinto
#47 69.32     n = self.fp.readinto(b)
#47 69.32   File "/usr/lib/python3.8/socket.py", line 669, in readinto
#47 69.32     return self._sock.recv_into(b)
#47 69.32   File "/usr/lib/python3.8/ssl.py", line 1241, in recv_into
#47 69.32     return self.read(nbytes, buffer)
#47 69.32   File "/usr/lib/python3.8/ssl.py", line 1099, in read
#47 69.32     return self._sslobj.read(len, buffer)
#47 69.32 socket.timeout: The read operation timed out
```

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
