### PR TITLE
Fixed: Issue with point region doesn't work in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed tasks in project autoannotation (<https://github.com/openvinotoolkit/cvat/pull/2725>)
 - Cuboids are missed in annotations statistics (<https://github.com/openvinotoolkit/cvat/pull/2704>)
 - The list of files attached to the task is not displayed (<https://github.com/openvinotoolkit/cvat/pull/2706>)
+- Issue with point region doesn't work in Firefox (<https://github.com/openvinotoolkit/cvat/pull/2727>)
 
 ### Security
 

--- a/cvat-canvas/package-lock.json
+++ b/cvat-canvas/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-canvas",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-canvas/package.json
+++ b/cvat-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-canvas",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Part of Computer Vision Annotation Tool which presents its canvas library",
   "main": "src/canvas.ts",
   "scripts": {

--- a/cvat-canvas/src/typescript/regionSelector.ts
+++ b/cvat-canvas/src/typescript/regionSelector.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-canvas/src/typescript/regionSelector.ts
+++ b/cvat-canvas/src/typescript/regionSelector.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -66,7 +66,7 @@ export class RegionSelectorImpl implements RegionSelector {
                     'stroke-width': consts.BASE_STROKE_WIDTH / this.geometry.scale,
                 })
                 .addClass('cvat_canvas_shape_region_selection');
-            this.selectionRect.attr({ ...this.startSelectionPoint });
+            this.selectionRect.attr({ ...this.startSelectionPoint, width: 1, height: 1 });
         }
     };
 
@@ -78,7 +78,7 @@ export class RegionSelectorImpl implements RegionSelector {
             } = this.selectionRect.bbox();
             this.selectionRect.remove();
             this.selectionRect = null;
-            if (w === 0 && h === 0) {
+            if (w <= 1 && h <= 1) {
                 this.onRegionSelected([x - offset, y - offset]);
             } else {
                 this.onRegionSelected([x - offset, y - offset, x2 - offset, y2 - offset]);


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
This one is probably browser issue, not CVAT. 
If width or height of a SVG rectangle are 0, than getBBox() returns all 0 (even for x1, x2 which are actually not 0 according to current element attributes). Chrome works correct in this case, Firefox doesn't. Workaround-ed. 

Resolved #2633 

### How has this been tested?
Manual testing

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```

Hi @dvkruchinin , do we have tests that creates issue by one tab on the canvas? 
