### PR TITLE
Fix cypress test "Drawing with predefined number of points" due fail in Firefox browser.

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_34_drawing_with_predefined_number_points.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_34_drawing_with_predefined_number_points.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -58,7 +58,7 @@ context('Drawing with predefined number of points.', () => {
 
     function tryDeletePoint() {
         let svgJsCircleId = [];
-        cy.get('#cvat_canvas_shape_1').trigger('mousemove').should('have.attr', 'fill-opacity', 0.3);
+        cy.get('#cvat_canvas_shape_1').trigger('mousemove', { force: true }).should('have.attr', 'fill-opacity', 0.3);
         cy.get('circle').then((circle) => {
             for (let i = 0; i < circle.length; i++) {
                 if (circle[i].id.match(/^SvgjsCircle\d+$/)) {


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
I think the problem is in the interaction of Cypress and Firefox. Cypress uses scroll to the element when interacting: https://docs.cypress.io/guides/core-concepts/interacting-with-elements.html#Scrolling
It looks like this:
Chrome:
![case_34_chrome](https://user-images.githubusercontent.com/33020454/106248807-913c7280-6222-11eb-88ec-49eb5465c06d.JPG)

Firefox:
![case_34_firefox](https://user-images.githubusercontent.com/33020454/106248828-9ac5da80-6222-11eb-8ff7-4d95bc1fbac1.JPG)

And tries to produce a “mousemove” event on the element. In this case, it failed with an error
```
is being covered by another element:
`<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs" id="cvat_canvas_content" …
```

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
