### PR TITLE
Update Cypress test. Some parts of the Redux state (issues) isn't reset after changing a task.

### DIFF
--- a/tests/cypress/integration/actions_users/issue_2524_2633_issue_not_reset_after_change_task_issue_point_firefox.js
+++ b/tests/cypress/integration/actions_users/issue_2524_2633_issue_not_reset_after_change_task_issue_point_firefox.js
@@ -1,15 +1,15 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 
 /// <reference types="cypress" />
 
 context("Some parts of the Redux state (issues) isn't reset after chaning a task.", () => {
-    const issueId = '2524';
-    const labelName = `Case ${issueId}`;
+    const issueId = '2524_2633';
+    const labelName = `Issue ${issueId}`;
     const taskName = {
-        firstTaskName: 'First task issue 2524',
-        secondTaskName: 'Second task issue 2524',
+        firstTaskName: `First task issue ${issueId}`,
+        secondTaskName: `Second task issue ${issueId}`,
     };
     const attrName = `Attr for ${labelName}`;
     const textDefaultValue = 'Some default value for type Text';
@@ -32,6 +32,12 @@ context("Some parts of the Redux state (issues) isn't reset after chaning a task
         firstY: 100,
         secondX: 650,
         secondY: 200,
+    };
+    const createIssuePoint = {
+        type: 'point',
+        description: 'point issue',
+        firstX: 500,
+        firstY: 300,
     };
 
     before(() => {
@@ -83,9 +89,10 @@ context("Some parts of the Redux state (issues) isn't reset after chaning a task
             cy.url().should('include', '/tasks');
         });
 
-        it('Open job again and create an issue', () => {
+        it('Open job again and create an issue. Check issue 2633.', () => {
             cy.openJob();
             cy.createIssueFromControlButton(createIssueRectangle);
+            cy.createIssueFromControlButton(createIssuePoint); // Issue 2633
         });
 
         it('Open the second task. Open job. Issue not exist.', () => {

--- a/tests/cypress/support/commands_review_pipeline.js
+++ b/tests/cypress/support/commands_review_pipeline.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -120,7 +120,9 @@ Cypress.Commands.add('createIssueFromControlButton', (createIssueParams) => {
             .trigger('mousemove', createIssueParams.secondX, createIssueParams.secondY)
             .trigger('mouseup');
     } else if (createIssueParams.type === 'point') {
-        cy.get('.cvat-canvas-container').click(createIssueParams.firstX, createIssueParams.firstY);
+        cy.get('.cvat-canvas-container')
+            .trigger('mousedown', createIssueParams.firstX, createIssueParams.firstY, { button: 0 })
+            .trigger('mouseup');
     }
     cy.get('.cvat-create-issue-dialog').within(() => {
         cy.get('#issue_description').type(createIssueParams.description);


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Adding creation an issue as a point. Check #2633 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
