### PR TITLE
Cypress test. Call HOC component each render.

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/issue_2753_call_HOC_component_each_render.js
+++ b/tests/cypress/integration/actions_tasks_objects/issue_2753_call_HOC_component_each_render.js
@@ -1,0 +1,77 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName, labelName } from '../../support/const';
+
+context('Call HOC component each render.', () => {
+    const issueId = '2753';
+    const numberOfPointsPolygon = 4;
+    const numberOfPointsPolyline = 5;
+    const numberOfPointsPoint = 6;
+
+    const createPolygonShapePoints = {
+        reDraw: false,
+        type: 'Shape',
+        labelName: labelName,
+        pointsMap: [
+            { x: 200, y: 200 },
+            { x: 250, y: 200 },
+            { x: 250, y: 250 },
+            { x: 200, y: 300 },
+        ],
+        numberOfPoints: numberOfPointsPolygon,
+    };
+    const createPolylinesTrackPoints = {
+        type: 'Track',
+        labelName: labelName,
+        pointsMap: [
+            { x: 300, y: 200 },
+            { x: 350, y: 200 },
+            { x: 350, y: 250 },
+            { x: 300, y: 350 },
+            { x: 270, y: 330 },
+        ],
+        numberOfPoints: numberOfPointsPolyline,
+    };
+    const createPointsShapePoints = {
+        type: 'Shape',
+        labelName: labelName,
+        pointsMap: [
+            { x: 400, y: 200 },
+            { x: 450, y: 200 },
+            { x: 450, y: 250 },
+            { x: 450, y: 230 },
+            { x: 430, y: 230 },
+            { x: 400, y: 230 },
+        ],
+        numberOfPoints: numberOfPointsPoint,
+    };
+
+    function checkNumberOfPointsValue(objectType, numberOfPoints) {
+        cy.get(`.cvat-draw-${objectType}-control`).trigger('mouseover');
+        cy.get(`.cvat-draw-${objectType}-popover-visible`).within(() => {
+            cy.get('.cvat-draw-shape-popover-points-selector')
+                .find('input')
+                .should('have.attr', 'value', numberOfPoints);
+        });
+        cy.get(`.cvat-draw-${objectType}-control`).trigger('mouseout');
+    }
+
+    before(() => {
+        cy.openTaskJob(taskName);
+    });
+
+    describe(`Testing issue "${issueId}"`, () => {
+        it('Draw polygon, polyline, points. After drawing "Number of points" popover value should the same.', () => {
+            cy.createPolygon(createPolygonShapePoints);
+            cy.createPolyline(createPolylinesTrackPoints);
+            cy.createPoint(createPointsShapePoints);
+            checkNumberOfPointsValue('polygon', numberOfPointsPolygon);
+            checkNumberOfPointsValue('polyline', numberOfPointsPolyline);
+            checkNumberOfPointsValue('points', numberOfPointsPoint);
+        });
+    });
+});


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Add Cypress test for issue #2753 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
