### PR TITLE
Improved maintanance of popups visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped nuclio version to 1.5.16
 - All methods for interative segmentation accept negative points as well
 - Persistent queue added to logstash (<https://github.com/openvinotoolkit/cvat/pull/2744>)
+- Improved maintanance of popups visibility (<https://github.com/openvinotoolkit/cvat/pull/2809>)
 
 ### Deprecated
 

--- a/cvat-ui/package-lock.json
+++ b/cvat-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/handle-popover-visibility.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/handle-popover-visibility.tsx
@@ -27,13 +27,14 @@ function useCurrentActivePopover(): string | null {
 
     useEffect(() => {
         const listener: PopoverTypeListener = (newActivePopover: string | null) => {
+            // updating the state leads to rerender of dependent components
             setActivePopover(newActivePopover);
         };
 
+        // subscribe on mount and unsubscribe on unmount
         subscribePopoverUpdate(listener);
-
         return () => unsubscribePopoverUpdate(listener);
-    });
+    }, []);
 
     return activePopover;
 }

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/handle-popover-visibility.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/handle-popover-visibility.tsx
@@ -2,33 +2,79 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Popover, { PopoverProps } from 'antd/lib/popover';
+
+type PopoverTypeListener = (activePopover: string | null) => void;
+
+let listeners: PopoverTypeListener[] = [];
+function updateActivePopoverType(activePopover: string | null): void {
+    for (const listener of listeners) {
+        listener(activePopover);
+    }
+}
+
+function subscribePopoverUpdate(onUpdate: PopoverTypeListener): void {
+    listeners.push(onUpdate);
+}
+
+function unsubscribePopoverUpdate(onUpdate: PopoverTypeListener): void {
+    listeners = listeners.filter((listener: PopoverTypeListener) => listener !== onUpdate);
+}
+
+function useCurrentActivePopover(): string | null {
+    const [activePopover, setActivePopover] = useState<string | null>(null);
+
+    useEffect(() => {
+        const listener: PopoverTypeListener = (newActivePopover: string | null) => {
+            setActivePopover(newActivePopover);
+        };
+
+        subscribePopoverUpdate(listener);
+
+        return () => unsubscribePopoverUpdate(listener);
+    });
+
+    return activePopover;
+}
 
 export default function withVisibilityHandling(WrappedComponent: typeof Popover, popoverType: string) {
     return (props: PopoverProps): JSX.Element => {
         const [initialized, setInitialized] = useState<boolean>(false);
         const [visible, setVisible] = useState<boolean>(false);
-        let { overlayClassName } = props;
-        if (typeof overlayClassName !== 'string') overlayClassName = '';
+        const currentActivePopover = useCurrentActivePopover();
+        const { overlayClassName, ...rest } = props;
+        const overlayClassNames = typeof overlayClassName === 'string' ? overlayClassName.split(/\s+/) : [];
 
-        overlayClassName += ` cvat-${popoverType}-popover`;
+        const popoverClassName = `cvat-${popoverType}-popover`;
+        overlayClassNames.push(popoverClassName);
         if (visible) {
-            overlayClassName += ` cvat-${popoverType}-popover-visible`;
+            const visiblePopoverClassName = `cvat-${popoverType}-popover-visible`;
+            overlayClassNames.push(visiblePopoverClassName);
         }
 
         const callback = (event: Event): void => {
             if ((event as AnimationEvent).animationName === 'antZoomBigIn') {
+                updateActivePopoverType(popoverType);
                 setVisible(true);
             }
         };
 
         return (
             <WrappedComponent
-                {...props}
-                overlayClassName={overlayClassName.trim()}
+                {...rest}
+                trigger={visible && currentActivePopover === popoverType ? 'click' : 'hover'}
+                overlayClassName={overlayClassNames.join(' ').trim()}
                 onVisibleChange={(_visible: boolean) => {
-                    if (!_visible) setVisible(false);
+                    if (!_visible) {
+                        setVisible(false);
+                    } else {
+                        // Hide other popovers
+                        const element = window.document.getElementsByClassName(`${popoverClassName}`)[0];
+                        if (element) {
+                            element.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+                        }
+                    }
                     if (!initialized) {
                         const self = window.document.getElementsByClassName(`cvat-${popoverType}-popover`)[0];
                         self?.addEventListener('animationend', callback);


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Resolved #2713
Resolved #2230

### How has this been tested?
Manual testing

@dvkruchinin 
We need a test to cover this case
Good gif to reproducing: https://user-images.githubusercontent.com/1630974/105646611-0fa2b880-5ea1-11eb-95ea-45a9c214491e.gif

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
