### PR TITLE
Update Cypress tests.

### DIFF
--- a/tests/cypress/integration/actions_projects/registration_involved/base_actions_project_task_user.js
+++ b/tests/cypress/integration/actions_projects/registration_involved/base_actions_project_task_user.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -112,6 +112,7 @@ context('Base actions on the project', () => {
             cy.get('.cvat-constructor-viewer').should('not.exist');
         });
         it('Logout first user, register second user, tries to create project and logout.', () => {
+            cy.goToTaskList();
             cy.logout();
             cy.goToRegisterPage();
             cy.userRegistration(firstName, lastName, userName, emailAddr, password);
@@ -141,6 +142,7 @@ context('Base actions on the project', () => {
             cy.goToTaskList();
             cy.contains('strong', taskName.secondTask).should('not.exist');
             cy.openTask(taskName.firstTask);
+            cy.goToTaskList();
             cy.logout(userName);
         });
         it('Delete the project. Deleted project not exist. Checking the availability of tasks.', () => {

--- a/tests/cypress/integration/actions_tasks_objects/case_50_settings_player_speed.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_50_settings_player_speed.js
@@ -18,7 +18,7 @@ context('Settings. "Player speed" option.', () => {
     function changePlayerSpeed(speed) {
         cy.openSettings();
         cy.get('.cvat-player-settings-speed').within(() => {
-            cy.get('.cvat-player-settings-speed-select').click();
+            cy.get('.cvat-player-settings-speed-select').click().wait(300); // Wait for the dropdown menu transition.
         });
         cy.get(`.cvat-player-settings-speed-${speed}`).click();
         cy.get('.cvat-player-settings-speed-select').should(


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Add goToTaskList() before user logout. Due to the fact that when logging out of the task, it can be transferred to 
http://localhost:8080/auth/login/?next=/tasks/<task_id> and and when you go to /auth/login, it automatically jumps to the task page.

Added wait() for the dropdown menu transition.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
