### PR TITLE
Cypress. Fix some tests for antd 4.12.0

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_1_create_delete_task.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_1_create_delete_task.js
@@ -21,7 +21,6 @@ context('Create and delete a annotation task', () => {
     const archivePath = `cypress/fixtures/${archiveName}`;
     const imagesFolder = `cypress/fixtures/${imageFileName}`;
     const directoryToArchive = imagesFolder;
-    let taskID = '';
 
     before(() => {
         cy.visit('auth/login');
@@ -41,7 +40,8 @@ context('Create and delete a annotation task', () => {
         it('Deleted task not exist', () => {
             cy.contains('strong', taskName)
                 .parents('.cvat-tasks-list-item')
-                .should('have.attr', 'style', 'pointer-events: none; opacity: 0.5;');
+                .should('have.attr', 'style')
+                .and('contain', 'pointer-events: none; opacity: 0.5;');
         });
     });
 });

--- a/tests/cypress/integration/actions_users/registration_involved/case_4_assign_taks_job_users.js
+++ b/tests/cypress/integration/actions_users/registration_involved/case_4_assign_taks_job_users.js
@@ -129,9 +129,6 @@ context('Multiple users. Assign task, job.', () => {
             cy.contains('strong', taskName).should('exist');
             cy.deleteTask(taskName);
             cy.closeNotification('.cvat-notification-notice-delete-task-failed');
-            cy.contains('.cvat-item-task-name', taskName)
-                .parents('.cvat-tasks-list-item')
-                .should('not.have.attr', 'style');
             cy.openTask(taskName);
             cy.logout(thirdUserName);
         });


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Fix Cypress tests for antd 4.12.0

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
