### PR TITLE
CLI- Task list improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CLI - task list now returns a list of current tasks. (<https://github.com/openvinotoolkit/cvat/pull/2863>)
 - Updated HTTPS install README section (cleanup and described more robust deploy)
 - Logstash is improved for using with configurable elasticsearch outputs (<https://github.com/openvinotoolkit/cvat/pull/2531>)
 - Bumped nuclio version to 1.5.16 (<https://github.com/openvinotoolkit/cvat/pull/2578>)

--- a/utils/cli/core/core.py
+++ b/utils/cli/core/core.py
@@ -43,20 +43,25 @@ class CLI():
         url = self.api.tasks
         response = self.session.get(url)
         response.raise_for_status()
+        output = []
         page = 1
         while True:
             response_json = response.json()
+            output+= response_json['results']
             for r in response_json['results']:
                 if use_json_output:
                     log.info(json.dumps(r, indent=4))
                 else:
                     log.info('{id},{name},{status}'.format(**r))
+
+                
             if not response_json['next']:
-                return
+                return output
             page += 1
             url = self.api.tasks_page(page)
             response = self.session.get(url)
             response.raise_for_status()
+        return output
 
     def tasks_create(self, name, labels, overlap, segment_size, bug, resource_type, resources,
                      annotation_path='', annotation_format='CVAT XML 1.1',

--- a/utils/cli/core/core.py
+++ b/utils/cli/core/core.py
@@ -47,14 +47,12 @@ class CLI():
         page = 1
         while True:
             response_json = response.json()
-            output+= response_json['results']
+            output += response_json['results']
             for r in response_json['results']:
                 if use_json_output:
                     log.info(json.dumps(r, indent=4))
                 else:
                     log.info('{id},{name},{status}'.format(**r))
-
-                
             if not response_json['next']:
                 return output
             page += 1


### PR DESCRIPTION
This small PR helps to do many things using the current cli.
By returning the currently available tasks instead of just printing them, we can manipulate tasks using the CLI easily, e.g. removing tasks, dumping automatically, and uploading annotations.

It also helped me understand the data structure behind tasks in CVAT by analyzing the output tasks. 

Missing functionality: Creating projects using cli. 

