### PR TITLE
Fixed: Incorrect text on the warning when specifying an incorrect link to the issue tracker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed project search field updating (<https://github.com/openvinotoolkit/cvat/pull/2901>)
 - Fixed export error when invalid polygons are present in overlapping frames (<https://github.com/openvinotoolkit/cvat/pull/2852>)
 - Fixed image quality option for tasks created from images (<https://github.com/openvinotoolkit/cvat/pull/2963>)
+- Incorrect text on the warning when specifying an incorrect link to the issue tracker (<https://github.com/openvinotoolkit/cvat/pull/2971>)
 
 ### Security
 

--- a/cvat-ui/package-lock.json
+++ b/cvat-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.15.3",
+  "version": "1.15.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.15.3",
+  "version": "1.15.5",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/create-task-page/create-task-content.tsx
+++ b/cvat-ui/src/components/create-task-page/create-task-content.tsx
@@ -194,12 +194,11 @@ class CreateTaskContent extends React.PureComponent<Props & RouteComponentProps,
                 .catch((error: Error | ValidateErrorEntity): void => {
                     notification.error({
                         message: 'Could not create a task',
-                        description:
-                            error instanceof Error ?
-                                error.toString() :
-                                error.errorFields
-                                    .map((field) => `${field.name} : ${field.errors.join(';')}`)
-                                    .map((text: string): JSX.Element => <div>{text}</div>),
+                        description: (error as ValidateErrorEntity).errorFields ?
+                            (error as ValidateErrorEntity).errorFields
+                                .map((field) => `${field.name} : ${field.errors.join(';')}`)
+                                .map((text: string): JSX.Element => <div>{text}</div>) :
+                            error.toString(),
                         className: 'cvat-notification-create-task-fail',
                     });
                 });

--- a/cvat-ui/src/components/create-task-page/create-task-content.tsx
+++ b/cvat-ui/src/components/create-task-page/create-task-content.tsx
@@ -11,6 +11,8 @@ import Button from 'antd/lib/button';
 import Collapse from 'antd/lib/collapse';
 import notification from 'antd/lib/notification';
 import Text from 'antd/lib/typography/Text';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { ValidateErrorEntity } from 'rc-field-form/lib/interface';
 
 import ConnectedFileManager from 'containers/file-manager/file-manager';
 import LabelsEditor from 'components/labels-editor/labels-editor';
@@ -183,19 +185,21 @@ class CreateTaskContent extends React.PureComponent<Props & RouteComponentProps,
                     if (this.advancedConfigurationComponent.current) {
                         return this.advancedConfigurationComponent.current.submit();
                     }
-
-                    return new Promise<void>((resolve): void => {
-                        resolve();
-                    });
+                    return Promise.resolve();
                 })
                 .then((): void => {
                     const { onCreate } = this.props;
                     onCreate(this.state);
                 })
-                .catch((error: Error): void => {
+                .catch((error: Error | ValidateErrorEntity): void => {
                     notification.error({
                         message: 'Could not create a task',
-                        description: error.toString(),
+                        description:
+                            error instanceof Error ?
+                                error.toString() :
+                                error.errorFields
+                                    .map((field) => `${field.name} : ${field.errors.join(';')}`)
+                                    .map((text: string): JSX.Element => <div>{text}</div>),
                         className: 'cvat-notification-create-task-fail',
                     });
                 });


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Resolved #2967

### How has this been tested?
Manual testing

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
