### PR TITLE
Cypress test. Canvas 3d-m4. Check resize views.

### DIFF
--- a/tests/cypress/integration/canvas3d_functionality/case_56_canvas3d_functionality_basic_actions.js
+++ b/tests/cypress/integration/canvas3d_functionality/case_56_canvas3d_functionality_basic_actions.js
@@ -60,11 +60,6 @@ context('Canvas 3D functionality. Basic actions.', () => {
         cy.openTaskJob(taskName);
     });
 
-    after(() => {
-        cy.goToTaskList();
-        cy.deleteTask(taskName);
-    });
-
     describe(`Testing case "${caseId}"`, () => {
         it('Check existing of elements.', () => {
             cy.get('.cvat-canvas3d-perspective')

--- a/tests/cypress/integration/canvas3d_functionality/case_62_canvas3d_functionality_views_resize.js
+++ b/tests/cypress/integration/canvas3d_functionality/case_62_canvas3d_functionality_views_resize.js
@@ -1,0 +1,83 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { taskName } from '../../support/const_canvas3d';
+context('Canvas 3D functionality. Resize views.', () => {
+    const caseId = '62';
+    let widthHightArrBeforeResize = [];
+    let widthHightArrAfterResize = [];
+
+    function getViewWidthHeight(element, arrToPush) {
+        cy.get(element)
+            .find('canvas')
+            .invoke('attr', 'width')
+            .then(($topviewWidth) => {
+                cy.get(element)
+                    .find('canvas')
+                    .invoke('attr', 'height')
+                    .then(($topviewHeight) => {
+                        arrToPush.push([$topviewWidth, $topviewHeight]);
+                    });
+            });
+    }
+
+    before(() => {
+        cy.openTaskJob(taskName);
+        getViewWidthHeight('.cvat-canvas3d-perspective', widthHightArrBeforeResize);
+        getViewWidthHeight('.cvat-canvas3d-topview', widthHightArrBeforeResize);
+        getViewWidthHeight('.cvat-canvas3d-sideview', widthHightArrBeforeResize);
+        getViewWidthHeight('.cvat-canvas3d-frontview', widthHightArrBeforeResize);
+    });
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Resizing perspective.', () => {
+            cy.get('.cvat-resizable-handle-horizontal').trigger('mousedown', { button: 0, scrollBehavior: false });
+            cy.get('.cvat-canvas3d-perspective')
+                .trigger('mousemove', 600, 300, { scrollBehavior: false })
+                .trigger('mouseup');
+            getViewWidthHeight('.cvat-canvas3d-perspective', widthHightArrAfterResize);
+        });
+
+        it('Resizing topview.', () => {
+            cy.get('.cvat-resizable-handle-vertical-top').trigger('mousedown', { button: 0, scrollBehavior: false });
+            cy.get('.cvat-canvas3d-topview')
+                .trigger('mousemove', 200, 200, { scrollBehavior: false })
+                .trigger('mouseup');
+            getViewWidthHeight('.cvat-canvas3d-topview', widthHightArrAfterResize);
+        });
+
+        it('Resizing sideview.', () => {
+            cy.get('.cvat-resizable-handle-vertical-side').trigger('mousedown', { button: 0, scrollBehavior: false });
+            cy.get('.cvat-canvas3d-frontview')
+                .trigger('mousemove', 200, 200, { scrollBehavior: false })
+                .trigger('mouseup');
+            getViewWidthHeight('.cvat-canvas3d-sideview', widthHightArrAfterResize);
+            getViewWidthHeight('.cvat-canvas3d-frontview', widthHightArrAfterResize);
+        });
+
+        it('Checking for elements resizing.', () => {
+            expect(widthHightArrBeforeResize[0][0]).to.be.equal(widthHightArrAfterResize[0][0]); // Width of cvat-canvas3d-perspective before and after didn't change
+            expect(widthHightArrBeforeResize[0][1]).not.be.equal(widthHightArrAfterResize[0][1]); // Height of cvat-canvas3d-perspective changed
+            expect(widthHightArrAfterResize[1][1])
+                .to.be.equal(widthHightArrAfterResize[2][1])
+                .to.be.equal(widthHightArrAfterResize[3][1]); // Top/side/front has equal height after changes
+            [
+                [widthHightArrBeforeResize[1][0], widthHightArrAfterResize[1][0]],
+                [widthHightArrBeforeResize[2][0], widthHightArrAfterResize[2][0]],
+                [widthHightArrBeforeResize[3][0], widthHightArrAfterResize[3][0]],
+            ].forEach(([widthBefore, widthAfter]) => {
+                expect(widthBefore).not.be.equal(widthAfter); // Width of top/side/front changed
+            });
+            [
+                [widthHightArrBeforeResize[1][1], widthHightArrAfterResize[1][1]],
+                [widthHightArrBeforeResize[2][1], widthHightArrAfterResize[2][1]],
+                [widthHightArrBeforeResize[3][1], widthHightArrAfterResize[3][1]],
+            ].forEach(([heightBefore, heightAfter]) => {
+                expect(heightBefore).not.be.equal(heightAfter); // Height of top/side/front changed
+            });
+        });
+    });
+});

--- a/tests/cypress/integration/canvas3d_functionality/case_62_canvas3d_functionality_views_resize.js
+++ b/tests/cypress/integration/canvas3d_functionality/case_62_canvas3d_functionality_views_resize.js
@@ -5,6 +5,7 @@
 /// <reference types="cypress" />
 
 import { taskName } from '../../support/const_canvas3d';
+
 context('Canvas 3D functionality. Resize views.', () => {
     const caseId = '62';
     let widthHightArrBeforeResize = [];


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

Depends on #2891 

### Motivation and context
Cypress test. Checking for resizing views.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
