### PR TITLE
Cypress. Fix some tests. Rework margin.

### DIFF
--- a/cvat-ui/src/components/annotation-page/styles.scss
+++ b/cvat-ui/src/components/annotation-page/styles.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/components/annotation-page/styles.scss
+++ b/cvat-ui/src/components/annotation-page/styles.scss
@@ -103,7 +103,7 @@
 
     > span {
         font-size: 25px;
-        margin: 0 7px;
+        margin: 0 4px;
         color: $player-buttons-color;
 
         &:hover {

--- a/tests/cypress/integration/actions_tasks_objects/case_13_merge_split_features.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_13_merge_split_features.js
@@ -129,7 +129,6 @@ context('Merge/split features', () => {
             cy.get('.cvat-split-track-control').click();
             // A single click does not reproduce the split a track scenario in cypress test.
             cy.get('#cvat_canvas_shape_3').click().click();
-            cy.get('#cvat_canvas_shape_3').click(); // TODO: workaraund. Need to figure out and make it work with just single click
             cy.get('#cvat_canvas_shape_4').should('exist').and('be.hidden');
             cy.get('#cvat-objects-sidebar-state-item-4')
                 .should('contain', '4')

--- a/tests/cypress/integration/actions_tasks_objects/case_51_settings_auto_save.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_51_settings_auto_save.js
@@ -24,9 +24,10 @@ context('Settings. "Auto save" option.', () => {
                 cy.get('.ant-checkbox-checked').should('not.exist');
             });
             cy.get('.cvat-workspace-settings-auto-save-interval').within(() => {
-                cy.get('[role="spinbutton"]').clear().tab(); // Clear field and press Tab
-                cy.get('[role="spinbutton"]').should('have.value', 1); // Interval should`t be empty
-                cy.get('[role="spinbutton"]').clear().type(5).should('have.value', 5);
+                cy.get('[role="spinbutton"]').clear().type(0).tab();
+                cy.get('[role="spinbutton"]').should('have.value', 1); // Interval should`t be less then 1
+                cy.get('[role="spinbutton"]').clear().type(5).tab();
+                cy.get('[role="spinbutton"]').should('have.value', 5);
             });
         });
     });


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Several tests failed with an error in nightly CI. This patch is intended to solve the issue.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
