### PR TITLE
Update Cypress test "Button "Continue" in label editor".

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_33_button_continue_label_editor.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_33_button_continue_label_editor.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2020-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -28,6 +28,15 @@ context('Button "Continue" in label editor.', () => {
                 expect(labelNames).to.include(additionalLabels[0]);
                 expect(labelNames).to.include(additionalLabels[1]);
                 expect(labelNames).to.include(additionalLabels[2]);
+            });
+        });
+
+        it('Try add label with empty name. Alert should be visible.', () => {
+            cy.get('.cvat-constructor-viewer-new-item').click();
+            cy.get('.cvat-label-constructor-creator').within(() => {
+                cy.contains('button', 'Continue').click();
+                cy.contains('[role="alert"]', 'Please specify a name').should('be.visible');
+                cy.contains('button', 'Cancel').click();
             });
         });
     });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -541,7 +541,7 @@ Cypress.Commands.add('addNewLabel', (newLabelName, additionalAttrs, labelColor) 
 Cypress.Commands.add('addNewLabelViaContinueButton', (additionalLabels) => {
     cy.collectLabelsName().then((labelsNames) => {
         if (additionalLabels.some((el) => labelsNames.indexOf(el) === -1)) {
-            cy.contains('button', 'Add label').click();
+            cy.get('.cvat-constructor-viewer-new-item').click();
             for (let j = 0; j < additionalLabels.length; j++) {
                 cy.get('[placeholder="Label name"]').type(additionalLabels[j]);
                 if (j !== additionalLabels.length - 1) {


### PR DESCRIPTION
Update cypress command.

<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Add check adding a label with empty name via ```Continue``` button.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
