### PR TITLE
Update cypress test. Label constructor. Color label. Label name editing.

### DIFF
--- a/tests/cypress/integration/actions_tasks_objects/case_31_label_constructor_color_name_label.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_31_label_constructor_color_name_label.js
@@ -125,5 +125,57 @@ context('Label constructor. Color label. Label name editing', () => {
                 });
             });
         });
+
+        it('Cancel/reset button interaction when changing color of the label.', () => {
+            cy.goToTaskList();
+            cy.openTask(taskName);
+            // Adding a label without setting a color
+            cy.addNewLabel(`Case ${caseId}`);
+            cy.get('.cvat-constructor-viewer').should('be.visible');
+            cy.contains('.cvat-constructor-viewer-item', `Case ${caseId}`)
+                .invoke('attr', 'style')
+                .then(($labelColor) => {
+                    // Change the label color and press "Cancel"
+                    cy.contains('.cvat-constructor-viewer-item', `Case ${caseId}`).find('[data-icon="edit"]').click();
+                    cy.get('.cvat-change-task-label-color-badge')
+                        .children()
+                        .invoke('attr', 'style')
+                        .then(($labelBadgeColor) => {
+                            expect($labelBadgeColor).to.be.equal($labelColor);
+                        });
+                    cy.get('.cvat-change-task-label-color-button').click();
+                    cy.get('.cvat-label-color-picker')
+                        .not('.ant-popover-hidden')
+                        .within(() => {
+                            cy.contains('hex').prev().clear().type(labelColor.yellowHex);
+                            cy.contains('button', 'Cancel').click();
+                        });
+                    cy.get('.cvat-change-task-label-color-badge')
+                        .children()
+                        .invoke('attr', 'style')
+                        .then(($labelBadgeColor) => {
+                            expect($labelBadgeColor).to.be.equal($labelColor);
+                        });
+
+                    // Change the label color
+                    cy.get('.cvat-change-task-label-color-button').click();
+                    cy.changeColorViaBadge(labelColor.yellowHex);
+
+                    // Reset the label color
+                    cy.get('.cvat-change-task-label-color-button').click();
+                    cy.get('.cvat-label-color-picker')
+                        .not('.ant-popover-hidden')
+                        .within(() => {
+                            cy.contains('button', 'Reset').click();
+                        });
+                    cy.get('.cvat-change-task-label-color-badge')
+                        .children()
+                        .should('have.attr', 'style', 'background: rgb(179, 179, 179);');
+                    cy.get('.cvat-label-constructor-updater').contains('button', 'Done').click();
+                    cy.contains('.cvat-constructor-viewer-item', `Case ${caseId}`)
+                        .should('have.attr', 'style')
+                        .and('contain', $labelColor);
+                });
+        });
     });
 });

--- a/tests/cypress/integration/actions_tasks_objects/case_31_label_constructor_color_name_label.js
+++ b/tests/cypress/integration/actions_tasks_objects/case_31_label_constructor_color_name_label.js
@@ -170,7 +170,7 @@ context('Label constructor. Color label. Label name editing', () => {
                         });
                     cy.get('.cvat-change-task-label-color-badge')
                         .children()
-                        .should('have.attr', 'style', 'background: rgb(179, 179, 179);');
+                        .should('have.attr', 'style').and('contain', 'rgb(179, 179, 179)');
                     cy.get('.cvat-label-constructor-updater').contains('button', 'Done').click();
                     cy.contains('.cvat-constructor-viewer-item', `Case ${caseId}`)
                         .should('have.attr', 'style')


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Adding a reset/cancel buttons interaction.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
