### PR TITLE
add --project_id argument for create task

### DIFF
--- a/utils/cli/core/core.py
+++ b/utils/cli/core/core.py
@@ -66,16 +66,20 @@ class CLI():
                      completion_verification_period=20,
                      git_completion_verification_period=2,
                      dataset_repository_url='',
+                     project_id=None,
                      lfs=False, **kwargs):
         """ Create a new task with the given name and labels JSON and
         add the files to it. """
         url = self.api.tasks
+        labels = [] if project_id is not None else labels
         data = {'name': name,
                 'labels': labels,
                 'overlap': overlap,
                 'segment_size': segment_size,
                 'bug_tracker': bug,
         }
+        if project_id:
+            data.update({'project_id': project_id})
         response = self.session.post(url, json=data)
         response.raise_for_status()
         response_json = response.json()

--- a/utils/cli/core/definition.py
+++ b/utils/cli/core/definition.py
@@ -113,6 +113,12 @@ task_create_parser.add_argument(
     help='string or file containing JSON labels specification'
 )
 task_create_parser.add_argument(
+    '--project_id',
+    default=None,
+    type=int,
+    help='project ID if project exists'
+)
+task_create_parser.add_argument(
     '--overlap',
     default=0,
     type=int,
@@ -175,6 +181,7 @@ task_create_parser.add_argument(
     action='store_true',
     help='using lfs for dataset repository (default: %(default)s)'
 )
+
 #######################################################################
 # Delete
 #######################################################################

--- a/utils/cli/core/definition.py
+++ b/utils/cli/core/definition.py
@@ -113,7 +113,7 @@ task_create_parser.add_argument(
     help='string or file containing JSON labels specification'
 )
 task_create_parser.add_argument(
-    '--project_id',
+    '--project',
     default=None,
     type=int,
     help='project ID if project exists'


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
The new project feature is helpful, but it is not yet compatible with the CLI create task script. This PR adds the `--project_id` option for the create task and sets the labels to an empty list, which defaults to the project's labels.
The main changes are:
- add `project_id` paramater to the `task_create_parser` that defaults to `None`
- add `project_id` param to `tasks_create` in core.py
- sets labels to `[]` if using a project id, which defaults to the project's existing labels
- `project_id` follows formatting of `lowercase_param_name` used in other (eg `resource_type`)

Main goal is to be able to batch import via CLI into existing projects with existing label sets.

### How has this been tested?

Minimally tested using the following command:
```
docker exec -it cvat bash -ic \
  "python3 utils/cli/cli.py \
  --auth ${CVAT_USERNAME}:${CVAT_PASSWORD} \
  create --project_id 1 MyTaskName local /path/to/file.jpg"
```

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)
