### PR TITLE
Added DICOM conversion script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documentation on mask annotation (<https://github.com/openvinotoolkit/cvat/pull/3044>)
 - Hotkeys to switch a label of existing object or to change default label (for objects created with N) (<https://github.com/openvinotoolkit/cvat/pull/3070>)
+- A script to convert some kinds of DICOM files to regular images (<https://github.com/openvinotoolkit/cvat/pull/3095>)
 
 ### Changed
 

--- a/utils/dicom_converter/README.md
+++ b/utils/dicom_converter/README.md
@@ -11,5 +11,11 @@ DICOM files with series (multi-frame) are saved under the same name with a numbe
 python3 -m venv .env
 . .env/bin/activate
 pip install -r requirements.txt
-python3 script.py input_data output_data
+```
+
+# Running
+
+```
+. .env/bin/activate # if not activated
+python script.py input_data output_data
 ```

--- a/utils/dicom_converter/README.md
+++ b/utils/dicom_converter/README.md
@@ -1,0 +1,15 @@
+# Description
+
+The script is used to convert some kinds of DICOM data to regular images.
+Then you can annotate these images on CVAT and get a segmentation mask.
+The conversion script was tested on CT, MT and some multi-frame DICOM data.
+DICOM files with series (multi-frame) are saved under the same name with a number postfix: 001, 002, 003, etc.
+
+# Installation
+
+```bash
+python3 -m venv .env
+. .env/bin/activate
+pip install -r requirements.txt
+python3 script.py input_data output_data
+```

--- a/utils/dicom_converter/requirements.txt
+++ b/utils/dicom_converter/requirements.txt
@@ -1,0 +1,4 @@
+numpy==1.20.2
+Pillow==8.2.0
+pydicom==2.1.2
+tqdm==4.60.0

--- a/utils/dicom_converter/script.py
+++ b/utils/dicom_converter/script.py
@@ -80,7 +80,6 @@ def main(root_dir, output_root_dir):
     pbar = tqdm(dicom_files)
     for input_filename in pbar:
         pbar.set_description('Conversion: ' + input_filename)
-        input_subpath = input_filename.split(os.sep)[1:-1]
         input_basename = os.path.basename(input_filename)
 
         output_subpath = os.path.relpath(os.path.dirname(input_filename), root_dir)

--- a/utils/dicom_converter/script.py
+++ b/utils/dicom_converter/script.py
@@ -99,4 +99,4 @@ def main(root_dir, output_root_dir):
             logging.error(ex)
 
 if __name__ == '__main__':
-    main(args.input.strip(os.sep), args.output.strip(os.sep))
+    main(args.input.rstrip(os.sep), args.output.rstrip(os.sep))

--- a/utils/dicom_converter/script.py
+++ b/utils/dicom_converter/script.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+
+import os
+import argparse
+import logging
+from glob import glob
+
+import numpy as np
+from tqdm import tqdm
+from PIL import Image
+from pydicom import dcmread
+from pydicom.pixel_data_handlers.util import convert_color_space
+
+
+# Script configuration
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(message)s')
+parser = argparse.ArgumentParser(description='The script is used to convert some kinds of DICOM (.dcm) files to regular image files (.png)')
+parser.add_argument('input', type=str, help='A root directory with medical data files in DICOM format. The script finds all these files based on their extension')
+parser.add_argument('output', type=str, help='Where to save converted files. The script repeats internal directories structure of the input root directory')
+args = parser.parse_args()
+
+
+class Converter:
+    def __init__(self, filename):
+        with dcmread(filename) as ds:
+            self._pixel_array = ds.pixel_array
+            self._photometric_interpretation = ds.PhotometricInterpretation
+            self._min_value = ds.pixel_array.min()
+            self._max_value = ds.pixel_array.max()
+            self._depth = ds.BitsStored
+            try:
+                self._length = ds["NumberOfFrames"].value
+            except KeyError:
+                self._length = 1
+
+    def __len__(self):
+        return self._length
+
+    def __iter__(self):
+        if self._length == 1:
+            np.expand_dims(self._pixel_array, axis=0)
+
+        for pixel_array in self._pixel_array:
+            # Normalization to an output range 0..255, 0..65535
+            pixel_array = pixel_array - self._min_value
+            pixel_array = pixel_array * (2 ** self._depth - 1)
+            pixel_array = pixel_array // (self._max_value - self._min_value)
+
+            # In some cases we need to convert colors additionally
+            if 'YBR' in self._photometric_interpretation:
+                pixel_array = convert_color_space(pixel_array, self._photometric_interpretation, 'RGB')
+
+            if self._depth == 8:
+                image = Image.fromarray(pixel_array.astype(np.uint8))
+            elif self._depth == 16:
+                image = Image.fromarray(pixel_array.astype(np.uint16))
+            else:
+                raise Exception('Not supported depth {}'.format(self._depth))
+
+            yield image
+
+
+def main(root_dir, output_root_dir):
+    dicom_files = glob(os.path.join(root_dir, '**', '*.dcm'), recursive = True)
+    if not len(dicom_files):
+        logging.info('DICOM files are not found under the specified path')
+    else:
+        logging.info('Number of found DICOM files: ' + str(len(dicom_files)))
+
+    pbar = tqdm(dicom_files)
+    for input_filename in pbar:
+        pbar.set_description('Conversion: ' + input_filename)
+        input_subpath = input_filename.split(os.sep)[1:-1]
+        input_basename = os.path.basename(input_filename)
+
+        output_subpath = os.path.join(*input_filename.split(os.sep)[1:-1]) if len(input_subpath) else ''
+        output_path = os.path.join(output_root_dir, output_subpath)
+        output_basename = '{}.png'.format(os.path.splitext(input_basename)[0])
+        output_filename = os.path.join(output_path, output_basename)
+
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
+
+        try:
+            iterated_converter = Converter(input_filename)
+            length = len(iterated_converter)
+            for i, image in enumerate(iterated_converter):
+                if length == 1:
+                    image.save(output_filename)
+                else:
+                    filename_index = str(i).zfill(len(str(length)))
+                    list_output_filename = '{}_{}.png'.format(os.path.splitext(output_filename)[0], filename_index)
+                    image.save(list_output_filename)
+        except Exception as ex:
+            logging.error('Error while processing ' + input_filename)
+            logging.error(ex)
+
+if __name__ == '__main__':
+    main(args.input.strip(os.sep), args.output.strip(os.sep))


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
CVAT does not support DICOM format natively. 
One way to annotate DICOM data is to convert them to regular images first. The patch adds a script to support some kinds of DICOM files to .png

### How has this been tested?
Manual testing, converted:
- [CHAOS training set](https://zenodo.org/record/3362845) CT/MT
- Some multi-frame DICOM files from [here](https://www.aliza-dicom-viewer.com/download/datasets)

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [x] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
