### PR TITLE
Fix bug with hung web worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Export of instance masks with holes (<https://github.com/openvinotoolkit/cvat/pull/3044>)
 - Changing a label on canvas does not work when 'Show object details' enabled (<https://github.com/openvinotoolkit/cvat/pull/3084>)
+- Make sure frame unzip web worker correctly terminates after unzipping all images in a requested chunk (<https://github.com/openvinotoolkit/cvat/pull/3096>)
 
 ### Security
 

--- a/cvat-core/package-lock.json
+++ b/cvat-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-core",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-core/package.json
+++ b/cvat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-core",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Part of Computer Vision Tool which presents an interface for client-side integration",
   "main": "babel.config.js",
   "scripts": {

--- a/cvat-core/src/frames.js
+++ b/cvat-core/src/frames.js
@@ -286,7 +286,7 @@
                                 if (nextChunkNumber * chunkSize < this.stopFrame) {
                                     provider.setReadyToLoading(nextChunkNumber);
                                     const nextStart = nextChunkNumber * chunkSize;
-                                    const nextStop = (nextChunkNumber + 1) * chunkSize - 1;
+                                    const nextStop = Math.min(this.stopFrame, (nextChunkNumber + 1) * chunkSize - 1);
                                     if (!provider.isChunkCached(nextStart, nextStop)) {
                                         if (!frameDataCache[this.tid].activeChunkRequest) {
                                             frameDataCache[this.tid].activeChunkRequest = {


### PR DESCRIPTION
* Added upper limit to stop property of active chunk request

<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Fixes #3080. The unzip_imgs web worker was not getting terminated when loading the last chunk in a task. I added a stopFrame limit to the chunk request so that the web worker gets properly terminated once it unzips all images.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I manually tested this by uploading 71 frames, all 2048 x 2448 to exceed the cache limit, and made sure that the web worker is correctly terminated after loading the last chunk. I also made sure that scrolling back through the previous frames worked and that frames that had been removed from the cache are successfully loaded back in.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
