### PR TITLE
add cli kwargs for image_quality and frame_step when creating task

### DIFF
--- a/utils/cli/core/core.py
+++ b/utils/cli/core/core.py
@@ -23,7 +23,7 @@ class CLI():
         self.session = session
         self.login(credentials)
 
-    def tasks_data(self, task_id, resource_type, resources):
+    def tasks_data(self, task_id, resource_type, resources, **kwargs):
         """ Add local, remote, or shared files to an existing task. """
         url = self.api.tasks_id_data(task_id)
         data = {}
@@ -35,6 +35,13 @@ class CLI():
         elif resource_type == ResourceType.SHARE:
             data = {'server_files[{}]'.format(i): f for i, f in enumerate(resources)}
         data['image_quality'] = 50
+
+        ## capture additional kwargs
+        if 'image_quality' in kwargs:
+            data['image_quality'] = kwargs.get('image_quality')
+        if 'frame_step' in kwargs:
+            data['frame_filter'] = f"step={kwargs.get('frame_step')}"
+
         response = self.session.post(url, data=data, files=files)
         response.raise_for_status()
 

--- a/utils/cli/core/core.py
+++ b/utils/cli/core/core.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Intel Corporation
+# Copyright (C) 2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/utils/cli/core/core.py
+++ b/utils/cli/core/core.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2020-2021 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/utils/cli/core/core.py
+++ b/utils/cli/core/core.py
@@ -92,7 +92,7 @@ class CLI():
         response_json = response.json()
         log.info('Created task ID: {id} NAME: {name}'.format(**response_json))
         task_id = response_json['id']
-        self.tasks_data(task_id, resource_type, resources)
+        self.tasks_data(task_id, resource_type, resources, **kwargs)
 
         if annotation_path != '':
             url = self.api.tasks_id_status(task_id)

--- a/utils/cli/core/definition.py
+++ b/utils/cli/core/definition.py
@@ -181,7 +181,20 @@ task_create_parser.add_argument(
     action='store_true',
     help='using lfs for dataset repository (default: %(default)s)'
 )
-
+task_create_parser.add_argument(
+    '--image_quality',
+    default=70,
+    type=int,
+    help='''set the image quality option in the advanced configuration
+            when creating tasks.(default: %(default))'''
+)
+task_create_parser.add_argument(
+    '--frame_step',
+    default=1,
+    type=int,
+    help='''set the frame step option in the advanced configuration
+            when uploading image series or videos (default: %(default)s)'''
+)
 #######################################################################
 # Delete
 #######################################################################

--- a/utils/cli/core/definition.py
+++ b/utils/cli/core/definition.py
@@ -186,7 +186,7 @@ task_create_parser.add_argument(
     default=70,
     type=int,
     help='''set the image quality option in the advanced configuration
-            when creating tasks.(default: %(default))'''
+            when creating tasks.(default: %(default)s)'''
 )
 task_create_parser.add_argument(
     '--frame_step',


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
When using CLI to upload images to create tasks, we would like to have control over some advanced configuration like frame step and image quality. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
It has been tested using the tasks_create API by including additional kwargs (image_quality, frame_step):
`CLI.tasks_create(cli, name=name, labels=[], overlap=0, segment_size=0,
                             resource_type=ResourceType.argparse('local'),
                             resources=images, image_quality=iq, frame_step=frame_step,
                             project_id=pid, bug='')`

Maybe someone can help creating a test script ?

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
