### PR TITLE
Cypress test. Fix "Changing a default value for an attribute"

### DIFF
--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -51,11 +51,13 @@ context('Changing a default value for an attribute.', () => {
             cy.get('.cvat-label-constructor-updater').within(() => {
                 cy.get('.cvat-attribute-inputs-wrapper').then((wrapper) => {
                     for (let i = 0; i < wrapper.length; i++) {
+                        cy.task('log', `Before while ${wrapper[i].getAttribute('cvat-attribute-id')}`)
                         // Waiting for "cvat-attribute-id" value be greater then 0
                         while (Number(wrapper[i].getAttribute('cvat-attribute-id')) < 0) {
-                            cy.task('log', wrapper[i].getAttribute('cvat-attribute-id'))
                             cy.wait(500);
+                            cy.task('log', `In while ${wrapper[i].getAttribute('cvat-attribute-id')}`)
                         }
+                        cy.task('log', `After while ${wrapper[i].getAttribute('cvat-attribute-id')}`)
                         wrapperId.push(wrapper[i].getAttribute('cvat-attribute-id'));
                     }
                     const minId = Math.min(...wrapperId);

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -51,20 +51,19 @@ context('Changing a default value for an attribute.', () => {
             cy.get('.cvat-label-constructor-updater').within(() => {
                 cy.get('.cvat-attribute-inputs-wrapper').then((wrapper) => {
                     for (let i = 0; i < wrapper.length; i++) {
+                        // Waiting for "cvat-attribute-id" value be greater then 0
+                        while (Number(wrapper[i].getAttribute('cvat-attribute-id')) < 0) {
+                            cy.task('log', wrapper[i].getAttribute('cvat-attribute-id'))
+                            cy.wait(500);
+                        }
                         wrapperId.push(wrapper[i].getAttribute('cvat-attribute-id'));
                     }
                     const minId = Math.min(...wrapperId);
                     const maxId = Math.max(...wrapperId);
                     cy.task('log', `minId: ${minId}`)
                     cy.task('log', `maxId: ${maxId}`)
-                    // Since the id value can be less than 0, change the fields for clicking and entering the value
-                    if(minId > 0 && maxId > 0) {
-                        cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
-                        cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
-                    } else {
-                        cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
-                        cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').click();
-                    }
+                    cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
+                    cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
                 });
             });
             cy.get('.ant-select-dropdown').not('.ant-select-dropdown-hidden').within(() => {

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -55,13 +55,19 @@ context('Changing a default value for an attribute.', () => {
                     }
                     const minId = Math.min(...wrapperId);
                     const maxId = Math.max(...wrapperId);
-                    if (minId > 0 && maxId > 0 ) {
-                        cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
-                        cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
-                    } else {
-                        cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
-                        cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').click();
-                    }
+                    cy.task('log', `minId: ${minId}`)
+                    cy.task('log', `maxId: ${maxId}`)
+                    // Waiting for the value to become greater than zero.
+                    cy.get(`[cvat-attribute-id="${minId}"]`).invoke('attr', 'cvat-attribute-id').should(($id) => {
+                        expect(Number($id)).to.be.gt(0);
+                    });
+                    cy.get(`[cvat-attribute-id="${maxId}"]`).invoke('attr', 'cvat-attribute-id').should(($id) => {
+                        expect(Number($id)).to.be.gt(0);
+                    });
+                    cy.task('log', `minId after waiting: ${minId}`)
+                    cy.task('log', `maxId after waiting: ${maxId}`)
+                    cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
+                    cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
                 });
             });
             cy.get('.ant-select-dropdown').not('.ant-select-dropdown-hidden').within(() => {

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -26,6 +26,7 @@ context('Changing a default value for an attribute.', () => {
     const newTextValue = `${additionalLabel} text`;
     const newCheckboxValue = 'True';
     let wrapperId = [];
+    let wrapper;
 
     before(() => {
         cy.openTask(taskName);
@@ -48,22 +49,21 @@ context('Changing a default value for an attribute.', () => {
                     .find('[aria-label="edit"]')
                     .click({ force: true });
             });
+
+            cy.get('.cvat-label-constructor-updater')
+                .find('.cvat-attribute-inputs-wrapper')
+                .first()
+                .invoke('attr', 'cvat-attribute-id')
+                .then(parseInt)
+                .should('be.gt', 0);
+
             cy.get('.cvat-label-constructor-updater').within(() => {
                 cy.get('.cvat-attribute-inputs-wrapper').then((wrapper) => {
                     for (let i = 0; i < wrapper.length; i++) {
-                        cy.task('log', `Before while ${wrapper[i].getAttribute('cvat-attribute-id')}`)
-                        // Waiting for "cvat-attribute-id" value be greater then 0
-                        while (Number(wrapper[i].getAttribute('cvat-attribute-id')) < 0) {
-                            cy.wait(500);
-                            cy.task('log', `In while ${wrapper[i].getAttribute('cvat-attribute-id')}`)
-                        }
-                        cy.task('log', `After while ${wrapper[i].getAttribute('cvat-attribute-id')}`)
                         wrapperId.push(wrapper[i].getAttribute('cvat-attribute-id'));
                     }
                     const minId = Math.min(...wrapperId);
                     const maxId = Math.max(...wrapperId);
-                    cy.task('log', `minId: ${minId}`)
-                    cy.task('log', `maxId: ${maxId}`)
                     cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
                     cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
                 });

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -46,23 +46,8 @@ context('Changing a default value for an attribute.', () => {
                 cy.contains(new RegExp(`^${additionalLabel}$`))
                     .parents('.cvat-constructor-viewer-item')
                     .find('[aria-label="edit"]')
-                    .click({ force: true });
+                    .click();
             });
-
-            cy.get('.cvat-label-constructor-updater')
-                .find('.cvat-attribute-inputs-wrapper')
-                .first()
-                .invoke('attr', 'cvat-attribute-id')
-                .then(($wrapperId) => {
-                    cy.task('log', `####### First ID of cvat-attribute-id: ${$wrapperId}`);
-                });
-
-            cy.get('.cvat-label-constructor-updater')
-                .find('.cvat-attribute-inputs-wrapper')
-                .first()
-                .invoke('attr', 'cvat-attribute-id')
-                .then(parseInt)
-                .should('be.gt', 0);
 
             cy.get('.cvat-label-constructor-updater').within(() => {
                 cy.get('.cvat-attribute-inputs-wrapper').then((wrapper) => {
@@ -71,8 +56,6 @@ context('Changing a default value for an attribute.', () => {
                     }
                     const minId = Math.min(...wrapperId);
                     const maxId = Math.max(...wrapperId);
-                    cy.task('log', `####### minId: ${minId}`);
-                    cy.task('log', `####### maxId: ${maxId}`);
                     cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
                     cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
                 });

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -53,11 +53,16 @@ context('Changing a default value for an attribute.', () => {
                 .find('.cvat-attribute-inputs-wrapper')
                 .first()
                 .invoke('attr', 'cvat-attribute-id')
-                .then(parseInt)
-                .should('be.gt', 0)
                 .then(($wrapperId) => {
                     cy.task('log', `####### First ID of cvat-attribute-id: ${$wrapperId}`);
-                })
+                });
+
+            cy.get('.cvat-label-constructor-updater')
+                .find('.cvat-attribute-inputs-wrapper')
+                .first()
+                .invoke('attr', 'cvat-attribute-id')
+                .then(parseInt)
+                .should('be.gt', 0);
 
             cy.get('.cvat-label-constructor-updater').within(() => {
                 cy.get('.cvat-attribute-inputs-wrapper').then((wrapper) => {
@@ -66,6 +71,8 @@ context('Changing a default value for an attribute.', () => {
                     }
                     const minId = Math.min(...wrapperId);
                     const maxId = Math.max(...wrapperId);
+                    cy.task('log', `####### minId: ${minId}`);
+                    cy.task('log', `####### maxId: ${maxId}`);
                     cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
                     cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
                 });

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -47,7 +47,9 @@ context('Changing a default value for an attribute.', () => {
                     .parents('.cvat-constructor-viewer-item')
                     .find('[aria-label="edit"]')
                     .should('be.visible')
-                    .click();
+                    .then((e) => {
+                        cy.get(e).click();
+                    });
             });
 
             cy.get('.cvat-label-constructor-updater').within(() => {

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -57,13 +57,11 @@ context('Changing a default value for an attribute.', () => {
                     const maxId = Math.max(...wrapperId);
                     cy.task('log', `minId: ${minId}`)
                     cy.task('log', `maxId: ${maxId}`)
+
                     // Waiting for the value to become greater than zero.
-                    cy.get(`[cvat-attribute-id="${minId}"]`).invoke('attr', 'cvat-attribute-id').should(($id) => {
-                        expect(Number($id)).to.be.gt(0);
-                    });
-                    cy.get(`[cvat-attribute-id="${maxId}"]`).invoke('attr', 'cvat-attribute-id').should(($id) => {
-                        expect(Number($id)).to.be.gt(0);
-                    });
+                    cy.get(`[cvat-attribute-id="${minId}"]`).invoke('attr', 'cvat-attribute-id').then(parseInt).should('be.gt', 0);
+                    cy.get(`[cvat-attribute-id="${maxId}"]`).invoke('attr', 'cvat-attribute-id').then(parseInt).should('be.gt', 0);
+
                     cy.task('log', `minId after waiting: ${minId}`)
                     cy.task('log', `maxId after waiting: ${maxId}`)
                     cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -26,7 +26,6 @@ context('Changing a default value for an attribute.', () => {
     const newTextValue = `${additionalLabel} text`;
     const newCheckboxValue = 'True';
     let wrapperId = [];
-    let wrapper;
 
     before(() => {
         cy.openTask(taskName);
@@ -55,7 +54,10 @@ context('Changing a default value for an attribute.', () => {
                 .first()
                 .invoke('attr', 'cvat-attribute-id')
                 .then(parseInt)
-                .should('be.gt', 0);
+                .should('be.gt', 0)
+                .then(($wrapperId) => {
+                    cy.task('log', `####### First ID of cvat-attribute-id: ${$wrapperId}`);
+                })
 
             cy.get('.cvat-label-constructor-updater').within(() => {
                 cy.get('.cvat-attribute-inputs-wrapper').then((wrapper) => {

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -46,6 +46,7 @@ context('Changing a default value for an attribute.', () => {
                 cy.contains(new RegExp(`^${additionalLabel}$`))
                     .parents('.cvat-constructor-viewer-item')
                     .find('[aria-label="edit"]')
+                    .should('be.visible')
                     .click();
             });
 

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -57,15 +57,14 @@ context('Changing a default value for an attribute.', () => {
                     const maxId = Math.max(...wrapperId);
                     cy.task('log', `minId: ${minId}`)
                     cy.task('log', `maxId: ${maxId}`)
-
-                    // Waiting for the value to become greater than zero.
-                    cy.get(`[cvat-attribute-id="${minId}"]`).invoke('attr', 'cvat-attribute-id').then(parseInt).should('be.gt', 0);
-                    cy.get(`[cvat-attribute-id="${maxId}"]`).invoke('attr', 'cvat-attribute-id').then(parseInt).should('be.gt', 0);
-
-                    cy.task('log', `minId after waiting: ${minId}`)
-                    cy.task('log', `maxId after waiting: ${maxId}`)
-                    cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
-                    cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
+                    // Since the id value can be less than 0, change the fields for clicking and entering the value
+                    if(minId > 0 && maxId > 0) {
+                        cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
+                        cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
+                    } else {
+                        cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
+                        cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').click();
+                    }
                 });
             });
             cy.get('.ant-select-dropdown').not('.ant-select-dropdown-hidden').within(() => {

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -55,11 +55,16 @@ context('Changing a default value for an attribute.', () => {
                     }
                     const minId = Math.min(...wrapperId);
                     const maxId = Math.max(...wrapperId);
-                    cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
-                    cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click().wait(500); // Wait for the dropdown menu to transition.
+                    if (minId > 0 && maxId > 0 ) {
+                        cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
+                        cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').click();
+                    } else {
+                        cy.get(`[cvat-attribute-id="${maxId}"]`).find('.cvat-attribute-values-input').type(newTextValue);
+                        cy.get(`[cvat-attribute-id="${minId}"]`).find('.cvat-attribute-values-input').click();
+                    }
                 });
             });
-            cy.get('.ant-select-dropdown').within(() => {
+            cy.get('.ant-select-dropdown').not('.ant-select-dropdown-hidden').within(() => {
                 cy.contains(new RegExp(`^${newCheckboxValue}$`)).click();
             });
             cy.contains('[type="submit"]', 'Done').click();


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Any attempts to wait for the attribute value to change to positive failed. I reworked it so that the label change button was visible otherwise I got the ```Detached from the DOM``` error. Perhaps at this time react finishes processing the asynchronous function and the necessary elements get positive values.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
