### PR TITLE
Cypress test. Cropping polygon in some corner cases.

### DIFF
--- a/tests/cypress/integration/actions_objects2/case_77_cropping_polygon_in_some_corner_cases.js
+++ b/tests/cypress/integration/actions_objects2/case_77_cropping_polygon_in_some_corner_cases.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+import { labelName, taskName } from '../../support/const';
+
+context('Cropping polygon in some corner cases.', () => {
+    const caseId = '77';
+    const createPolygonShapeRightSide = {
+        reDraw: false,
+        type: 'Shape',
+        labelName: labelName,
+        pointsMap: [
+            { x: 500, y: 120 },
+            { x: 900, y: 10 },
+            { x: 850, y: 800 },
+            { x: 500, y: 750 },
+        ],
+        complete: true,
+        numberOfPoints: null,
+    };
+
+    const createPolygonShapeLeftSide = {
+        reDraw: false,
+        type: 'Shape',
+        labelName: labelName,
+        pointsMap: [
+            { x: 500, y: 120 },
+            { x: 30, y: 10 },
+            { x: 50, y: 800 },
+            { x: 500, y: 750 },
+        ],
+        complete: true,
+        numberOfPoints: null,
+    };
+
+    before(() => {
+        cy.openTask(taskName);
+        cy.openJob();
+    });
+
+    describe(`Testing case "${caseId}"`, () => {
+        it('Checking the right side of the canvas.', () => {
+            cy.get('.cvat-canvas-container').trigger('wheel', { deltaY: 5 }).trigger('wheel', { deltaY: 5 });
+            cy.createPolygon(createPolygonShapeRightSide);
+            cy.get('.cvat-canvas-container').trigger('mousemove', 650, 250); // Hover over a point that was free of the shape before the fix
+            cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
+        });
+
+        it('Checking the lift side of the canvas.', () => {
+            cy.removeAnnotations();
+            cy.createPolygon(createPolygonShapeLeftSide);
+            cy.get('.cvat-canvas-container').trigger('mousemove', 300, 250); // Hover over a point that was free of the shape before the fix
+            cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
+        });
+    });
+});


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Cypress test for PR #3184 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
