### PR TITLE
Add test for wrong attribute import in tracks

### DIFF
--- a/cvat/apps/dataset_manager/tests/assets/annotations.json
+++ b/cvat/apps/dataset_manager/tests/assets/annotations.json
@@ -1,5 +1,5 @@
 {
-  "CVAT for video 1.1 many jobs": {
+  "CVAT for video 1.1 attributes in tracks": {
     "version": 0,
     "tags": [],
     "shapes": [],
@@ -11,10 +11,10 @@
         "source": "manual",
         "shapes": [
           {
-            "type": "rectangle",
-            "occluded": true,
+            "type": "polygon",
+            "occluded": false,
             "z_order": 0,
-            "points": [4.75, 4.8, 13.06, 11.39],
+            "points": [25.04, 13.7, 35.85, 20.2, 16.65, 19.8],
             "frame": 1,
             "outside": false,
             "attributes": []
@@ -23,16 +23,16 @@
         "attributes": []
       },
       {
-        "frame": 10,
+        "frame": 8,
         "label_id": null,
         "group": 1,
         "source": "manual",
         "shapes": [
           {
-            "type": "polygon",
-            "occluded": false,
+            "type": "rectangle",
+            "occluded": true,
             "z_order": 0,
-            "points": [24.62, 13.01, 34.88, 20.03, 18.14, 18.08],
+            "points": [5.54, 3.5, 19.64, 11.19],
             "frame": 1,
             "outside": false,
             "attributes": []

--- a/cvat/apps/dataset_manager/tests/assets/annotations.json
+++ b/cvat/apps/dataset_manager/tests/assets/annotations.json
@@ -1,0 +1,45 @@
+{
+  "CVAT for video 1.1 many jobs": {
+    "version": 0,
+    "tags": [],
+    "shapes": [],
+    "tracks": [
+      {
+        "frame": 0,
+        "label_id": null,
+        "group": 0,
+        "source": "manual",
+        "shapes": [
+          {
+            "type": "rectangle",
+            "occluded": true,
+            "z_order": 0,
+            "points": [4.75, 4.8, 13.06, 11.39],
+            "frame": 1,
+            "outside": false,
+            "attributes": []
+          }
+        ],
+        "attributes": []
+      },
+      {
+        "frame": 10,
+        "label_id": null,
+        "group": 1,
+        "source": "manual",
+        "shapes": [
+          {
+            "type": "polygon",
+            "occluded": false,
+            "z_order": 0,
+            "points": [24.62, 13.01, 34.88, 20.03, 18.14, 18.08],
+            "frame": 1,
+            "outside": false,
+            "attributes": []
+          }
+        ],
+        "attributes": []
+      }
+    ]
+  }
+}

--- a/cvat/apps/dataset_manager/tests/assets/annotations.json
+++ b/cvat/apps/dataset_manager/tests/assets/annotations.json
@@ -59,27 +59,19 @@
             "occluded": false,
             "z_order": 0,
             "points": [25.04, 13.7, 35.85, 20.2, 16.65, 19.8],
-            "frame": 1,
-            "outside": false,
+            "frame": 0,
+            "outside": true,
             "attributes": []
-          }
-        ],
-        "attributes": []
-      },
-      {
-        "frame": 8,
-        "label_id": null,
-        "group": 1,
-        "source": "manual",
-        "shapes": [
+          },
           {
-            "type": "rectangle",
-            "occluded": true,
+            "type": "polygon",
+            "occluded": false,
             "z_order": 0,
-            "points": [5.54, 3.5, 19.64, 11.19],
+            "points": [25.04, 13.7, 35.85, 20.2, 16.65, 19.8],
             "frame": 1,
             "outside": false,
-            "attributes": []
+            "attributes": [],
+            "keyframe": true
           }
         ],
         "attributes": []

--- a/cvat/apps/dataset_manager/tests/assets/tasks.json
+++ b/cvat/apps/dataset_manager/tests/assets/tasks.json
@@ -1,0 +1,15 @@
+{
+  "many jobs": {
+    "name": "many jobs",
+    "overlap": 0,
+    "segment_size": 5,
+    "owner_id": 1,
+    "labels": [
+      {
+        "name": "car",
+        "color": "#2080c0",
+        "attributes": []
+      }
+    ]
+  }
+}

--- a/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
@@ -1,0 +1,233 @@
+# Copyright (C) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import copy
+import json
+import os.path as osp
+import random
+from io import BytesIO
+
+from datumaro.components.dataset import Dataset
+from datumaro.util.test_utils import TestDir, compare_datasets
+from django.contrib.auth.models import Group, User
+from PIL import Image
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from cvat.apps.dataset_manager.bindings import CvatTaskDataExtractor, TaskData
+from cvat.apps.dataset_manager.task import TaskAnnotation
+from cvat.apps.engine.models import Task
+
+path = osp.join(osp.dirname(__file__), 'assets', 'tasks.json')
+with open(path) as f:
+    tasks = json.load(f)
+
+path = osp.join(osp.dirname(__file__), 'assets', 'annotations.json')
+with open(path) as f:
+    annotations = json.load(f)
+
+def generate_image_file(filename, size=(100, 50)):
+    f = BytesIO()
+    image = Image.new('RGB', size=size)
+    image.save(f, 'jpeg')
+    f.name = filename
+    f.seek(0)
+    return f
+
+class ForceLogin:
+    def __init__(self, user, client):
+        self.user = user
+        self.client = client
+
+    def __enter__(self):
+        if self.user:
+            self.client.force_login(self.user,
+                backend='django.contrib.auth.backends.ModelBackend')
+
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        if self.user:
+            self.client.logout()
+
+class _DbTestBase(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.create_db_users()
+
+    @classmethod
+    def create_db_users(cls):
+        (group_admin, _) = Group.objects.get_or_create(name="admin")
+        (group_user, _) = Group.objects.get_or_create(name="user")
+
+        user_admin = User.objects.create_superuser(username="admin", email="",
+            password="admin")
+        user_admin.groups.add(group_admin)
+        user_dummy = User.objects.create_user(username="user", password="user")
+        user_dummy.groups.add(group_user)
+
+        cls.admin = user_admin
+        cls.user = user_dummy
+
+    def _put_api_v1_task_id_annotations(self, tid, data):
+        with ForceLogin(self.admin, self.client):
+            response = self.client.put("/api/v1/tasks/%s/annotations" % tid,
+                data=data, format="json")
+
+        return response
+
+    @staticmethod
+    def _generate_task_images(count): # pylint: disable=no-self-use
+        images = {"client_files[%d]" % i: generate_image_file("image_%d.jpg" % i) for i in range(count)}
+        images["image_quality"] = 75
+        return images
+
+    def _create_task(self, data, image_data):
+        with ForceLogin(self.user, self.client):
+            response = self.client.post('/api/v1/tasks', data=data, format="json")
+            assert response.status_code == status.HTTP_201_CREATED, response.status_code
+            tid = response.data["id"]
+
+            response = self.client.post("/api/v1/tasks/%s/data" % tid,
+                data=image_data)
+            assert response.status_code == status.HTTP_202_ACCEPTED, response.status_code
+
+            response = self.client.get("/api/v1/tasks/%s" % tid)
+            task = response.data
+
+        return task
+
+    def _get_request_with_data(self, path, data, user):
+        with ForceLogin(user, self.client):
+            response = self.client.get(path, data)
+        return response
+
+    def _put_request_with_data(self, path, data, user):
+        with ForceLogin(user, self.client):
+            response = self.client.put(path, data)
+        return response
+
+    def _delete_request(self, path, user):
+        with ForceLogin(user, self.client):
+            response = self.client.delete(path)
+        return response
+
+    def _create_annotations(self, task, name_ann, key_get_values):
+        tmp_annotations = copy.deepcopy(annotations[name_ann])
+
+        # change attributes in all annotations
+        for item in tmp_annotations:
+            if item in ["tags", "shapes", "tracks"]:
+                for index_elem, _ in enumerate(tmp_annotations[item]):
+                    tmp_annotations[item][index_elem]["label_id"] = task["labels"][0]["id"]
+
+                    for index_attribute, attribute in enumerate(task["labels"][0]["attributes"]):
+                        spec_id = task["labels"][0]["attributes"][index_attribute]["id"]
+
+                        if key_get_values == "random":
+                            if attribute["input_type"] == "number":
+                                start = int(attribute["values"][0])
+                                stop = int(attribute["values"][1]) + 1
+                                step = int(attribute["values"][2])
+                                value = str(random.randrange(start, stop, step))
+                            else:
+                                value = random.choice(task["labels"][0]["attributes"][index_attribute]["values"])
+                        elif key_get_values == "default":
+                            value = attribute["default_value"]
+
+                        if item == "tracks" and attribute["mutable"]:
+                            for index_shape, _ in enumerate(tmp_annotations[item][index_elem]["shapes"]):
+                                tmp_annotations[item][index_elem]["shapes"][index_shape]["attributes"].append({
+                                    "spec_id": spec_id,
+                                    "value": value,
+                                })
+                        else:
+                            tmp_annotations[item][index_elem]["attributes"].append({
+                                "spec_id": spec_id,
+                                "value": value,
+                            })
+
+        response = self._put_api_v1_task_id_annotations(task["id"], tmp_annotations)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def _download_file(self, url, data, user, file_name):
+        response = self._get_request_with_data(url, data, user)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        response = self._get_request_with_data(url, data, user)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        content = BytesIO(b"".join(response.streaming_content))
+        with open(file_name, "wb") as f:
+            f.write(content.getvalue())
+
+    def _upload_file(self, url, data, user):
+        response = self._put_request_with_data(url, {"annotation_file": data}, user)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        response = self._put_request_with_data(url, {}, user)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def _check_downloaded_file(self, file_name):
+        if not osp.exists(file_name):
+            raise FileNotFoundError(f"File '{file_name}' was not downloaded")
+
+    def _generate_url_dump_tasks_annotations(self, task_id):
+        return f"/api/v1/tasks/{task_id}/annotations"
+
+    def _generate_url_upload_tasks_annotations(self, task_id, upload_format_name):
+        return f"/api/v1/tasks/{task_id}/annotations?format={upload_format_name}"
+
+    def _remove_annotations(self, url, user):
+        response = self._delete_request(url, user)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        return response
+
+class TaskDumpUploadTest(_DbTestBase):
+    def test_attribute_import_in_tracks(self):
+        test_name = self._testMethodName
+        dump_format_name = "CVAT for video 1.1"
+        upload_format_name = "CVAT 1.1"
+
+        for include_images in (False, True):
+            with self.subTest():
+                # create task with annotations
+                images = self._generate_task_images(13)
+                task = self._create_task(tasks["many jobs"], images)
+                self._create_annotations(task, f'{dump_format_name} many jobs', "dafault")
+
+                task_id = task["id"]
+                task_ann = TaskAnnotation(task_id)
+                task_ann.init_from_db()
+                task_data = TaskData(task_ann.ir_data, Task.objects.get(pk=task_id))
+                extractor = CvatTaskDataExtractor(task_data, include_images=include_images)
+                data_from_task_before_upload = Dataset.from_extractors(extractor)
+
+                # dump annotations
+                url = self._generate_url_dump_tasks_annotations(task_id)
+                data = {
+                    "format": dump_format_name,
+                    "action": "download",
+                }
+                with TestDir() as test_dir:
+                    file_zip_name = osp.join(test_dir, f'{test_name}_{dump_format_name}.zip')
+                    self._download_file(url, data, self.admin, file_zip_name)
+                    self._check_downloaded_file(file_zip_name)
+
+                    # remove annotations
+                    self._remove_annotations(url, self.admin)
+
+                    # upload annotations
+                    url = self._generate_url_upload_tasks_annotations(task_id, upload_format_name)
+                    with open(file_zip_name, 'rb') as binary_file:
+                        self._upload_file(url, binary_file, self.admin)
+
+                    # equals annotations
+                    task_ann = TaskAnnotation(task_id)
+                    task_ann.init_from_db()
+                    task_data = TaskData(task_ann.ir_data, Task.objects.get(pk=task_id))
+                    extractor = CvatTaskDataExtractor(task_data, include_images=include_images)
+                    data_from_task_after_upload = Dataset.from_extractors(extractor)
+                    compare_datasets(self, data_from_task_before_upload, data_from_task_after_upload)

--- a/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
@@ -103,6 +103,13 @@ class _DbTestBase(APITestCase):
 
         return task
 
+    def _get_data_from_task(self, task_id, include_images):
+        task_ann = TaskAnnotation(task_id)
+        task_ann.init_from_db()
+        task_data = TaskData(task_ann.ir_data, Task.objects.get(pk=task_id))
+        extractor = CvatTaskDataExtractor(task_data, include_images=include_images)
+        return Dataset.from_extractors(extractor)
+
     def _get_request_with_data(self, path, data, user):
         with ForceLogin(user, self.client):
             response = self.client.get(path, data)
@@ -231,11 +238,7 @@ class TaskDumpUploadTest(_DbTestBase):
                 self._create_annotations(task, f'{dump_format_name}', "random")
 
                 task_id = task["id"]
-                task_ann = TaskAnnotation(task_id)
-                task_ann.init_from_db()
-                task_data = TaskData(task_ann.ir_data, Task.objects.get(pk=task_id))
-                extractor = CvatTaskDataExtractor(task_data, include_images=include_images)
-                data_from_task_before_upload = Dataset.from_extractors(extractor)
+                data_from_task_before_upload = self._get_data_from_task(task_id, include_images)
 
                 # dump annotations
                 url = self._generate_url_dump_tasks_annotations(task_id)
@@ -257,11 +260,7 @@ class TaskDumpUploadTest(_DbTestBase):
                         self._upload_file(url, binary_file, self.admin)
 
                     # equals annotations
-                    task_ann = TaskAnnotation(task_id)
-                    task_ann.init_from_db()
-                    task_data = TaskData(task_ann.ir_data, Task.objects.get(pk=task_id))
-                    extractor = CvatTaskDataExtractor(task_data, include_images=include_images)
-                    data_from_task_after_upload = Dataset.from_extractors(extractor)
+                    data_from_task_after_upload = self._get_data_from_task(task_id, include_images)
                     compare_datasets(self, data_from_task_before_upload, data_from_task_after_upload)\
 
     def test_api_v1_check_attribute_import_in_tracks(self):
@@ -277,11 +276,7 @@ class TaskDumpUploadTest(_DbTestBase):
                 self._create_annotations(task, f'{dump_format_name} attributes in tracks', "default")
 
                 task_id = task["id"]
-                task_ann = TaskAnnotation(task_id)
-                task_ann.init_from_db()
-                task_data = TaskData(task_ann.ir_data, Task.objects.get(pk=task_id))
-                extractor = CvatTaskDataExtractor(task_data, include_images=include_images)
-                data_from_task_before_upload = Dataset.from_extractors(extractor)
+                data_from_task_before_upload = self._get_data_from_task(task_id, include_images)
 
                 # dump annotations
                 url = self._generate_url_dump_tasks_annotations(task_id)
@@ -303,9 +298,5 @@ class TaskDumpUploadTest(_DbTestBase):
                         self._upload_file(url, binary_file, self.admin)
 
                     # equals annotations
-                    task_ann = TaskAnnotation(task_id)
-                    task_ann.init_from_db()
-                    task_data = TaskData(task_ann.ir_data, Task.objects.get(pk=task_id))
-                    extractor = CvatTaskDataExtractor(task_data, include_images=include_images)
-                    data_from_task_after_upload = Dataset.from_extractors(extractor)
+                    data_from_task_after_upload = self._get_data_from_task(task_id, include_images)
                     compare_datasets(self, data_from_task_before_upload, data_from_task_after_upload)

--- a/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
@@ -19,12 +19,12 @@ from cvat.apps.dataset_manager.bindings import CvatTaskDataExtractor, TaskData
 from cvat.apps.dataset_manager.task import TaskAnnotation
 from cvat.apps.engine.models import Task
 
-path = osp.join(osp.dirname(__file__), 'assets', 'tasks.json')
-with open(path) as f:
+tasks_path = osp.join(osp.dirname(__file__), 'assets', 'tasks.json')
+with open(tasks_path) as f:
     tasks = json.load(f)
 
-path = osp.join(osp.dirname(__file__), 'assets', 'annotations.json')
-with open(path) as f:
+annotations_path = osp.join(osp.dirname(__file__), 'assets', 'annotations.json')
+with open(annotations_path) as f:
     annotations = json.load(f)
 
 def generate_image_file(filename, size=(100, 50)):
@@ -196,7 +196,7 @@ class TaskDumpUploadTest(_DbTestBase):
                 # create task with annotations
                 images = self._generate_task_images(13)
                 task = self._create_task(tasks["many jobs"], images)
-                self._create_annotations(task, f'{dump_format_name} attributes in tracks', "dafault")
+                self._create_annotations(task, f'{dump_format_name} attributes in tracks', "default")
 
                 task_id = task["id"]
                 task_ann = TaskAnnotation(task_id)

--- a/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
+++ b/cvat/apps/dataset_manager/tests/test_rest_api_formats.py
@@ -186,7 +186,7 @@ class _DbTestBase(APITestCase):
         return response
 
 class TaskDumpUploadTest(_DbTestBase):
-    def test_attribute_import_in_tracks(self):
+    def test_api_v1_check_attribute_import_in_tracks(self):
         test_name = self._testMethodName
         dump_format_name = "CVAT for video 1.1"
         upload_format_name = "CVAT 1.1"
@@ -196,7 +196,7 @@ class TaskDumpUploadTest(_DbTestBase):
                 # create task with annotations
                 images = self._generate_task_images(13)
                 task = self._create_task(tasks["many jobs"], images)
-                self._create_annotations(task, f'{dump_format_name} many jobs', "dafault")
+                self._create_annotations(task, f'{dump_format_name} attributes in tracks', "dafault")
 
                 task_id = task["id"]
                 task_ann = TaskAnnotation(task_id)


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Add test for wrong attribute import in tracks #3229

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
