### PR TITLE
Fixed issue: is not a constructor when create object, save, undo, save, redo save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project page requests took a long time and did many DB queries (<https://github.com/openvinotoolkit/cvat/pull/3223>)
 - Fixed Python 3.6 support (<https://github.com/openvinotoolkit/cvat/pull/3258>)
 - Incorrect attribute import in tracks (<https://github.com/openvinotoolkit/cvat/pull/3229>)
+- Issue "is not a constructor" when create object, save, undo, save, redo save (<https://github.com/openvinotoolkit/cvat/pull/3292>)
 
 ### Security
 

--- a/cvat-core/package-lock.json
+++ b/cvat-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-core",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-core/package.json
+++ b/cvat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-core",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "Part of Computer Vision Tool which presents an interface for client-side integration",
   "main": "babel.config.js",
   "scripts": {

--- a/cvat-core/src/annotations-collection.js
+++ b/cvat-core/src/annotations-collection.js
@@ -788,6 +788,7 @@
                     () => {
                         importedArray.forEach((object) => {
                             object.removed = false;
+                            object.serverID = undefined;
                         });
                     },
                     importedArray.map((object) => object.clientID),

--- a/cvat-core/src/annotations-saver.js
+++ b/cvat-core/src/annotations-saver.js
@@ -1,11 +1,11 @@
-// Copyright (C) 2019-2020 Intel Corporation
+// Copyright (C) 2019-2021 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 
 (() => {
     const serverProxy = require('./server-proxy');
     const { Task } = require('./session');
-    const { ScriptingError } = './exceptions';
+    const { ScriptingError } = require('./exceptions');
 
     class AnnotationsSaver {
         constructor(version, collection, session) {

--- a/cvat-core/tests/api/annotations.js
+++ b/cvat-core/tests/api/annotations.js
@@ -311,6 +311,27 @@ describe('Feature: check unsaved changes', () => {
 });
 
 describe('Feature: save annotations', () => {
+    test('create, save, undo, save, redo save', async () => {
+        const task = (await window.cvat.tasks.get({ id: 101 }))[0];
+        await task.annotations.get(0);
+        const state = new window.cvat.classes.ObjectState({
+            frame: 0,
+            objectType: window.cvat.enums.ObjectType.SHAPE,
+            shapeType: window.cvat.enums.ObjectShape.POLYGON,
+            points: [0, 0, 100, 0, 100, 50],
+            occluded: true,
+            label: task.labels[0],
+            zOrder: 0,
+        });
+
+        await task.annotations.put([state]);
+        await task.annotations.save();
+        await task.actions.undo();
+        await task.annotations.save();
+        await task.actions.redo();
+        await task.annotations.save();
+    });
+
     test('create & save annotations for a task', async () => {
         const task = (await window.cvat.tasks.get({ id: 101 }))[0];
         let annotations = await task.annotations.get(0);


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Resolved #3216 

### How has this been tested?
Added a unit test. This is cvat-core error, end-to-end tests aren't required to cover it.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
