### PR TITLE
add option to change image_quality on task creation via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support of context images for 2D image tasks (<https://github.com/openvinotoolkit/cvat/pull/3122>)
+- Option to set image quality from images when creating a task using the CLI (<https://github.com/openvinotoolkit/cvat/pull/3297>)
 
 ### Changed
 

--- a/site/content/en/docs/for-developers/cli.md
+++ b/site/content/en/docs/for-developers/cli.md
@@ -12,7 +12,7 @@ comprehensive CVAT administration tool in the future.
 
 Overview of functionality:
 
-- Create a new task (supports name, bug tracker, labels JSON, local/share/remote files)
+- Create a new task (supports name, bug tracker, labels JSON, image quality, local/share/remote files)
 - Delete tasks (supports deleting a list of task IDs)
 - List all tasks (supports basic CSV or JSON output)
 - Download JPEG frames (supports a list of frame IDs)

--- a/utils/cli/core/core.py
+++ b/utils/cli/core/core.py
@@ -23,7 +23,7 @@ class CLI():
         self.session = session
         self.login(credentials)
 
-    def tasks_data(self, task_id, resource_type, resources):
+    def tasks_data(self, task_id, resource_type, image_quality, resources):
         """ Add local, remote, or shared files to an existing task. """
         url = self.api.tasks_id_data(task_id)
         data = {}
@@ -34,7 +34,7 @@ class CLI():
             data = {'remote_files[{}]'.format(i): f for i, f in enumerate(resources)}
         elif resource_type == ResourceType.SHARE:
             data = {'server_files[{}]'.format(i): f for i, f in enumerate(resources)}
-        data['image_quality'] = 50
+        data['image_quality'] = image_quality
         response = self.session.post(url, data=data, files=files)
         response.raise_for_status()
 
@@ -61,7 +61,7 @@ class CLI():
             response.raise_for_status()
         return output
 
-    def tasks_create(self, name, labels, overlap, segment_size, bug, resource_type, resources,
+    def tasks_create(self, name, labels, overlap, segment_size, image_quality, bug, resource_type, resources,
                      annotation_path='', annotation_format='CVAT XML 1.1',
                      completion_verification_period=20,
                      git_completion_verification_period=2,
@@ -85,7 +85,7 @@ class CLI():
         response_json = response.json()
         log.info('Created task ID: {id} NAME: {name}'.format(**response_json))
         task_id = response_json['id']
-        self.tasks_data(task_id, resource_type, resources)
+        self.tasks_data(task_id, resource_type, image_quality, resources)
 
         if annotation_path != '':
             url = self.api.tasks_id_status(task_id)

--- a/utils/cli/core/definition.py
+++ b/utils/cli/core/definition.py
@@ -137,6 +137,13 @@ task_create_parser.add_argument(
     help='bug tracker URL'
 )
 task_create_parser.add_argument(
+    '--image_quality',
+    default=50,
+    type=int,
+    help='value from 5 to 100 (higher is better) that defines the quality of loaded images'
+)
+
+task_create_parser.add_argument(
     'resource_type',
     default='local',
     choices=list(ResourceType),


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Hi, I'm new to CVAT and while working on automating my task creation using the CLI, I missed the option to select the image quality in which the images are loaded. The default value is currently hardcoded to 50%. This is not enough
for my case because the feature to be annotated is too small and usually ends up being lost during compression so I thought having the option to change it would be of some interest. 


<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [x] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
