### PR TITLE
Cypress. Case 44. Adding additional checks.

### DIFF
--- a/cvat-ui/src/components/labels-editor/constructor-viewer-item.tsx
+++ b/cvat-ui/src/components/labels-editor/constructor-viewer-item.tsx
@@ -31,6 +31,7 @@ export default function ConstructorViewerItem(props: ConstructorViewerItemProps)
                     tabIndex={0}
                     onClick={(): void => onUpdate(label)}
                     onKeyPress={(): boolean => false}
+                    className={`cvat-constructor-viewer-item-edit-${label.name.replace(' ', '-')}`}
                 >
                     <EditOutlined />
                 </span>
@@ -41,6 +42,7 @@ export default function ConstructorViewerItem(props: ConstructorViewerItemProps)
                     tabIndex={0}
                     onClick={(): void => onDelete(label)}
                     onKeyPress={(): boolean => false}
+                    className={`cvat-constructor-viewer-item-delete-${label.name.replace(' ', '-')}`}
                 >
                     <CloseOutlined />
                 </span>

--- a/cvat-ui/src/components/labels-editor/constructor-viewer-item.tsx
+++ b/cvat-ui/src/components/labels-editor/constructor-viewer-item.tsx
@@ -31,7 +31,6 @@ export default function ConstructorViewerItem(props: ConstructorViewerItemProps)
                     tabIndex={0}
                     onClick={(): void => onUpdate(label)}
                     onKeyPress={(): boolean => false}
-                    className={`cvat-constructor-viewer-item-edit-${label.name.replace(' ', '-')}`}
                 >
                     <EditOutlined />
                 </span>
@@ -42,7 +41,6 @@ export default function ConstructorViewerItem(props: ConstructorViewerItemProps)
                     tabIndex={0}
                     onClick={(): void => onDelete(label)}
                     onKeyPress={(): boolean => false}
-                    className={`cvat-constructor-viewer-item-delete-${label.name.replace(' ', '-')}`}
                 >
                     <CloseOutlined />
                 </span>

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -38,19 +38,20 @@ context('Changing a default value for an attribute.', () => {
             cy.addNewLabel(additionalLabel, additionalAttrsLabel);
             cy.wait('@patchTask').its('response.statusCode').should('equal', 200);
             cy.wait('@getTask').its('response.statusCode').should('equal', 200);
+            cy.get('.cvat-constructor-viewer').should('exist').and('be.visible');
         });
 
         it('Open label editor. Change default values for text & checkbox attributes, press Done.', () => {
             cy.intercept('PATCH', '/api/v1/tasks/**').as('patchTask');
-            cy.get(`.cvat-constructor-viewer-item-edit-${additionalLabel.replace(' ', '-')}`).should('be.visible').click();
-            // cy.get('.cvat-constructor-viewer').within(() => {
-            //     cy.contains(new RegExp(`^${additionalLabel}$`))
-            //         .parents('.cvat-constructor-viewer-item')
-            //         .should('be.visible')
-            //         .find('[aria-label="edit"]')
-            //         .should('be.visible')
-            //         .click();
-            // });
+            // cy.get(`.cvat-constructor-viewer-item-edit-${additionalLabel.replace(' ', '-')}`).should('be.visible').click();
+            cy.get('.cvat-constructor-viewer').within(() => {
+                cy.contains(new RegExp(`^${additionalLabel}$`))
+                    .parents('.cvat-constructor-viewer-item')
+                    .should('be.visible')
+                    .find('[aria-label="edit"]')
+                    .should('be.visible')
+                    .click();
+            });
 
             cy.get('.cvat-label-constructor-updater').within(() => {
                 cy.get('.cvat-attribute-inputs-wrapper').then((wrapper) => {
@@ -74,6 +75,7 @@ context('Changing a default value for an attribute.', () => {
                 )}.values'`,
             ).should('not.exist');
             cy.wait('@patchTask').its('response.statusCode').should('equal', 200);
+            cy.get('.cvat-constructor-viewer').should('exist').and('be.visible');
         });
 
         it('Open a job, create an object. Attribute values are correct.', () => {

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -43,7 +43,6 @@ context('Changing a default value for an attribute.', () => {
 
         it('Open label editor. Change default values for text & checkbox attributes, press Done.', () => {
             cy.intercept('PATCH', '/api/v1/tasks/**').as('patchTask');
-            // cy.get(`.cvat-constructor-viewer-item-edit-${additionalLabel.replace(' ', '-')}`).should('be.visible').click();
             cy.get('.cvat-constructor-viewer').within(() => {
                 cy.contains(new RegExp(`^${additionalLabel}$`))
                     .parents('.cvat-constructor-viewer-item')

--- a/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
+++ b/tests/cypress/integration/actions_tasks3/case_44_changing_default_value_for_attribute.js
@@ -42,15 +42,15 @@ context('Changing a default value for an attribute.', () => {
 
         it('Open label editor. Change default values for text & checkbox attributes, press Done.', () => {
             cy.intercept('PATCH', '/api/v1/tasks/**').as('patchTask');
-            cy.get('.cvat-constructor-viewer').within(() => {
-                cy.contains(new RegExp(`^${additionalLabel}$`))
-                    .parents('.cvat-constructor-viewer-item')
-                    .find('[aria-label="edit"]')
-                    .should('be.visible')
-                    .then((e) => {
-                        cy.get(e).click();
-                    });
-            });
+            cy.get(`.cvat-constructor-viewer-item-edit-${additionalLabel.replace(' ', '-')}`).should('be.visible').click();
+            // cy.get('.cvat-constructor-viewer').within(() => {
+            //     cy.contains(new RegExp(`^${additionalLabel}$`))
+            //         .parents('.cvat-constructor-viewer-item')
+            //         .should('be.visible')
+            //         .find('[aria-label="edit"]')
+            //         .should('be.visible')
+            //         .click();
+            // });
 
             cy.get('.cvat-label-constructor-updater').within(() => {
                 cy.get('.cvat-attribute-inputs-wrapper').then((wrapper) => {


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
This test often fails due to the ```aria-label="edit"``` visibility check when changing label attributes. 
```
Timed out retrying after 25000ms: `cy.should()` failed because this element is detached from the DOM.
```
Adding additional checks for the existence and visibility of the parent elements should solve this problem. This version of the updated test was tested in my fork by restarting jobs about 40 times. The test never failed with an error.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
