### PR TITLE
Update to Django 3.1.12.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated manifest format, added meta with related images (<https://github.com/openvinotoolkit/cvat/pull/3122>)
 - Update of COCO format documentation (<https://github.com/openvinotoolkit/cvat/pull/3197>)
 - Updated Webpack Dev Server config to add proxxy (<https://github.com/openvinotoolkit/cvat/pull/3368>)
+- Update to Django 3.1.12 (<https://github.com/openvinotoolkit/cvat/pull/3378>)
 
 ### Deprecated
 

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -275,7 +275,7 @@ class MyFileSystemStorage(FileSystemStorage):
         return name
 
 def upload_path_handler(instance, filename):
-    return os.path.join(instance.data.get_upload_dirname(), filename)
+    return os.path.join(os.path.relpath(instance.data.get_upload_dirname(), settings.BASE_DIR), filename)
 
 # For client files which the user is uploaded
 class ClientFile(models.Model):

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -275,6 +275,7 @@ class MyFileSystemStorage(FileSystemStorage):
         return name
 
 def upload_path_handler(instance, filename):
+    # relative path is required since Django 3.1.11
     return os.path.join(os.path.relpath(instance.data.get_upload_dirname(), settings.BASE_DIR), filename)
 
 # For client files which the user is uploaded

--- a/cvat/requirements/base.txt
+++ b/cvat/requirements/base.txt
@@ -1,5 +1,5 @@
 click==7.1.2
-Django==3.1.10
+Django==3.1.12
 django-appconf==1.0.4
 django-auth-ldap==2.2.0
 django-cacheops==5.0.1

--- a/cvat/settings/testing.py
+++ b/cvat/settings/testing.py
@@ -5,12 +5,13 @@
 from .development import *
 import tempfile
 
-_temp_dir = tempfile.TemporaryDirectory(suffix="cvat")
+_temp_dir = tempfile.TemporaryDirectory(dir=BASE_DIR, suffix="cvat")
+BASE_DIR = _temp_dir.name
 
-DATA_ROOT = os.path.join(_temp_dir.name, 'data')
+DATA_ROOT = os.path.join(BASE_DIR, 'data')
 os.makedirs(DATA_ROOT, exist_ok=True)
 
-SHARE_ROOT = os.path.join(_temp_dir.name, 'share')
+SHARE_ROOT = os.path.join(BASE_DIR, 'share')
 os.makedirs(SHARE_ROOT, exist_ok=True)
 
 MEDIA_DATA_ROOT = os.path.join(DATA_ROOT, 'data')
@@ -30,7 +31,7 @@ os.makedirs(CACHE_ROOT, exist_ok=True)
 
 # To avoid ERROR django.security.SuspiciousFileOperation:
 # The joined path (...) is located outside of the base path component
-MEDIA_ROOT = _temp_dir.name
+MEDIA_ROOT = BASE_DIR
 
 # Suppress all logs by default
 for logger in LOGGING["loggers"].values():


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There is one commit in Django 3.1.11 which change the logic of file name validation (https://github.com/django/django/commit/b7d4a6fa650f97982cf9ca246ddfa623d685487b). Before this commit it checked file name and transformed it by CVAT function to full upload path. After commit at first CVAT function give absolute path then Django check obtained path and failed with error SuspiciousFileOperation because it is the absolute path.

It leads to failures with response code 400 while trying to create a new task.

It is needed to change function `upload_path_handler` in `cvat/cvat/apps/engine/models.py` and don’t use absolute paths to avoid this error.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
