### PR TITLE
Fixed cvat_ui image build in case of OOM error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Duplication of the cuboids when redraw them (<https://github.com/openvinotoolkit/cvat/pull/3308>)
 - Some code issues in Deep Extreme Cut handler code (<https://github.com/openvinotoolkit/cvat/pull/3325>)
 - UI fails when inactive user is assigneed to a task/job (<https://github.com/openvinotoolkit/cvat/pull/3343>)
+- Falsely successful `cvat_ui` image build in case of OOM error that leads to the default nginx welcome page
+  (<https://github.com/openvinotoolkit/cvat/pull/3379>)
 
 ### Security
 

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS cvat-ui
+FROM node:lts-buster AS cvat-ui
 
 ARG http_proxy
 ARG https_proxy
@@ -14,8 +14,6 @@ ENV TERM=xterm \
     socks_proxy=${socks_proxy} \
     LANG='C.UTF-8'  \
     LC_ALL='C.UTF-8'
-
-RUN apk add python3 g++ make
 
 # Install dependencies
 COPY cvat-core/package*.json /tmp/cvat-core/


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->
Fixed cvat_ui image build in case of OOM error.
There seems to be a bug in npm v6.x with signal handling on alpine based images only https://github.com/npm/cli/issues/2103 and it won't be fixed for v6.x. This bug is not reproducible on debian buster based images and is not reproducible for npm v 7.x.
We are currently unable to switch to npm 7 easily, so I suggest using a buster based image as the first stage.

### Motivation and context
resolve #2989

### How has this been tested?
Previously, building the image with the following command `docker build --memory 500M -f Dockerfile.ui .` was successful, although` npm run build` was killed; for now it handles correctly

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
~~- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly~~
~~- [ ] I have added tests to cover my changes~~
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
~~- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
