### PR TITLE
Cypress test. Update case 90 for check issue "Context image disappears after undo/redo".

### DIFF
--- a/tests/cypress/integration/actions_tasks3/case_90_context_image.js
+++ b/tests/cypress/integration/actions_tasks3/case_90_context_image.js
@@ -11,6 +11,15 @@ context('Context images for 2D tasks.', () => {
     const attrName = `Attr for ${labelName}`;
     const textDefaultValue = 'color';
     const pathToArchive = `../../${__dirname}/assets/case_90/case_90_context_image.zip`;
+    const createRectangleShape2Points = {
+        points: 'By 2 Points',
+        type: 'Shape',
+        labelName: labelName,
+        firstX: 250,
+        firstY: 350,
+        secondX: 350,
+        secondY: 450,
+    };
 
     function previewRotate (directionRotation, expectedDeg) {
         if (directionRotation === 'right') {
@@ -102,6 +111,16 @@ context('Context images for 2D tasks.', () => {
         it('Preview a context image. Cancel preview.', () => {
             cy.get('.ant-image-preview-wrap').type('{Esc}');
             cy.get('.ant-image-preview-wrap').should('have.attr', 'style').and('contain', 'display: none')
+        });
+
+        it('Checking issue "Context image disappears after undo/redo".', () => {
+            cy.createRectangle(createRectangleShape2Points);
+            cy.contains('.cvat-annotation-header-button', 'Undo').click();
+            cy.get('.cvat-context-image').should('have.attr', 'src');
+            cy.get('#cvat_canvas_shape_1').should('not.exist');
+            cy.contains('.cvat-annotation-header-button', 'Redo').click();
+            cy.get('.cvat-context-image').should('have.attr', 'src');
+            cy.get('#cvat_canvas_shape_1').should('exist');
         });
     });
 });


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Testing #3416 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
