### PR TITLE
Cypress. Update case72. Adding a check "Attribute keeping when changing label" feature.

### DIFF
--- a/tests/cypress/integration/actions_tasks/case_72_hotkeys_change_labels.js
+++ b/tests/cypress/integration/actions_tasks/case_72_hotkeys_change_labels.js
@@ -9,7 +9,7 @@ context('Hotkeys to change labels feature.', () => {
     const labelName = `Case ${caseId}`;
     const taskName = labelName;
     const attrName = `Attr for ${labelName}`;
-    const textDefaultValue = 'Some default value for type Text';
+    const textDefaultValue = '2';
     const imagesCount = 1;
     const imageFileName = `image_${labelName.replace(' ', '_').toLowerCase()}`;
     const width = 800;
@@ -22,6 +22,9 @@ context('Hotkeys to change labels feature.', () => {
     const imagesFolder = `cypress/fixtures/${imageFileName}`;
     const directoryToArchive = imagesFolder;
     const secondLabel = `Case ${caseId} second`
+    const additionalAttrsSecondLabel = [
+        { additionalAttrName: attrName, additionalValue: '0;3;1', typeAttribute: 'Number', mutable: false },
+    ];
     let firstLabelCurrentVal = '';
     let secondLabelCurrentVal = '';
 
@@ -45,7 +48,7 @@ context('Hotkeys to change labels feature.', () => {
         cy.createZipArchive(directoryToArchive, archivePath);
         cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, archiveName);
         cy.openTask(taskName);
-        cy.addNewLabel(secondLabel);
+        cy.addNewLabel(secondLabel, additionalAttrsSecondLabel);
         cy.openJob();
     });
 
@@ -69,7 +72,7 @@ context('Hotkeys to change labels feature.', () => {
             });
         });
 
-        it('Changing a label for a shape using hotkey.', () => {
+        it('Changing a label for a shape using hotkey. Check "Attribute keeping when changing label" feature.', () => {
             const createPolygonShape = {
                 reDraw: false,
                 type: 'Shape',
@@ -89,9 +92,18 @@ context('Hotkeys to change labels feature.', () => {
             cy.get('.cvat-canvas-container').click(270, 260);
             cy.get('#cvat_canvas_shape_1').should('have.class', 'cvat_canvas_shape_activated');
             cy.contains('tspan', `${firstLabelCurrentVal} 1 (manual)`).should('be.visible');
+
+            // Check "Attribute keeping when changing label" feature
+            cy.get('#cvat-objects-sidebar-state-item-1').find('.cvat-objects-sidebar-state-item-collapse').click();
             cy.get('body').type('{Ctrl}2')
             cy.get('#cvat-objects-sidebar-state-item-1').find('.cvat-objects-sidebar-state-item-label-selector').should('have.text', secondLabelCurrentVal);
             cy.contains('tspan', `${secondLabelCurrentVal} 1 (manual)`).should('be.visible');
+            // The value of the attribute of the 2nd label corresponds to the value of the attribute of the same name of the 1st label
+            cy.get('#cvat-objects-sidebar-state-item-1')
+                .find('.cvat-object-item-number-attribute')
+                .find('input')
+                .should('have.attr', 'aria-valuenow', textDefaultValue);
+
             // Unset settings "Always show object details"
             testCheckingAlwaysShowObjectDetails();
         });


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Adding a check "Attribute keeping when changing label" feature.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
