### PR TITLE
Logstash PR fix

### DIFF
--- a/components/analytics/logstash/logstash.conf
+++ b/components/analytics/logstash/logstash.conf
@@ -124,7 +124,7 @@ output {
   if [type] == "client" {
     elasticsearch {
       hosts => ["${LOGSTASH_OUTPUT_HOST}"]
-      index => "cvat.client"
+      index => "%{[@metadata][target_index_client]}"
       user => "${LOGSTASH_OUTPUT_USER:}"
       password => "${LOGSTASH_OUTPUT_PASS:}"
       manage_template => false
@@ -132,7 +132,7 @@ output {
   } else if [type] == "server" {
     elasticsearch {
       hosts => ["${LOGSTASH_OUTPUT_HOST}"]
-      index => "cvat.server"
+      index => "%{[@metadata][target_index_server]}"
       user => "${LOGSTASH_OUTPUT_USER:}"
       password => "${LOGSTASH_OUTPUT_PASS:}"
       manage_template => false


### PR DESCRIPTION

### Motivation and context
This is a fix for this https://github.com/openvinotoolkit/cvat/pull/2531 PR
Now logs from logstash will be distributed across multiple indexes according to current year and month. This is done for better flexibility and index management.

### How has this been tested?
It was tested manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
