### PR TITLE
Cypress test. Activating the test scenario for check "Move a task between projects".

### DIFF
--- a/tests/cypress/integration/actions_projects_models/case_94_move_task_between_projects.js
+++ b/tests/cypress/integration/actions_projects_models/case_94_move_task_between_projects.js
@@ -80,7 +80,6 @@ context('Move a task between projects.', () => {
     });
 
     describe(`Testing "Case ${caseID}"`, () => {
-        // Waiting to fix https://github.com/openvinotoolkit/cvat/issues/3281
         it('Move a task between projects from a project.', () => {
             checkTask(secondProject.name, 'not.exist');
             checkTask(firtsProject.name, 'exist');

--- a/tests/cypress/integration/actions_projects_models/case_94_move_task_between_projects.js
+++ b/tests/cypress/integration/actions_projects_models/case_94_move_task_between_projects.js
@@ -81,7 +81,7 @@ context('Move a task between projects.', () => {
 
     describe(`Testing "Case ${caseID}"`, () => {
         // Waiting to fix https://github.com/openvinotoolkit/cvat/issues/3281
-        it.skip('Move a task between projects from a project.', () => {
+        it('Move a task between projects from a project.', () => {
             checkTask(secondProject.name, 'not.exist');
             checkTask(firtsProject.name, 'exist');
             cy.movingTask(taskName, secondProject.name, firtsProject.label, secondProject.label);


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Checking the scenario corrected in #3475 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
