### PR TITLE
Update Cypress tests. Added the use of the "Done" button.

### DIFF
--- a/tests/cypress/integration/actions_objects2/case_10_polygon_shape_track_label_points.js
+++ b/tests/cypress/integration/actions_objects2/case_10_polygon_shape_track_label_points.js
@@ -18,7 +18,6 @@ context('Actions on polygon.', () => {
             { x: 250, y: 200 },
             { x: 250, y: 250 },
         ],
-        complete: true,
     };
     const createPolygonTrack = {
         reDraw: false,
@@ -29,7 +28,6 @@ context('Actions on polygon.', () => {
             { x: 350, y: 200 },
             { x: 350, y: 350 },
         ],
-        complete: true,
     };
     const createPolygonShapePoints = {
         reDraw: false,
@@ -66,7 +64,7 @@ context('Actions on polygon.', () => {
             { x: 650, y: 200 },
             { x: 650, y: 250 },
         ],
-        useDoneButton: true,
+        finishWithButton: true,
     };
     const createPolygonTrackSwitchLabel = {
         reDraw: false,
@@ -77,7 +75,7 @@ context('Actions on polygon.', () => {
             { x: 750, y: 200 },
             { x: 750, y: 250 },
         ],
-        complete: true,
+        finishWithButton: true,
     };
 
     before(() => {
@@ -97,7 +95,7 @@ context('Actions on polygon.', () => {
             cy.createPolygon(createPolygonTrackPoints);
         });
 
-        it('Draw a polygon shape with second label and "Done" button, track with second label.', () => {
+        it('Draw a polygon shape, track with second label and "Done" button.', () => {
             cy.createPolygon(createPolygonShapeSwitchLabel);
             cy.createPolygon(createPolygonTrackSwitchLabel);
         });

--- a/tests/cypress/integration/actions_objects2/case_10_polygon_shape_track_label_points.js
+++ b/tests/cypress/integration/actions_objects2/case_10_polygon_shape_track_label_points.js
@@ -6,7 +6,7 @@
 
 import { taskName, labelName } from '../../support/const';
 
-context('Actions on polygon', () => {
+context('Actions on polygon.', () => {
     const caseId = '10';
     const newLabelName = `New label for case ${caseId}`;
     const createPolygonShape = {
@@ -19,7 +19,6 @@ context('Actions on polygon', () => {
             { x: 250, y: 250 },
         ],
         complete: true,
-        numberOfPoints: null,
     };
     const createPolygonTrack = {
         reDraw: false,
@@ -31,7 +30,6 @@ context('Actions on polygon', () => {
             { x: 350, y: 350 },
         ],
         complete: true,
-        numberOfPoints: null,
     };
     const createPolygonShapePoints = {
         reDraw: false,
@@ -68,8 +66,7 @@ context('Actions on polygon', () => {
             { x: 650, y: 200 },
             { x: 650, y: 250 },
         ],
-        complete: true,
-        numberOfPoints: null,
+        useDoneButton: true,
     };
     const createPolygonTrackSwitchLabel = {
         reDraw: false,
@@ -81,7 +78,6 @@ context('Actions on polygon', () => {
             { x: 750, y: 250 },
         ],
         complete: true,
-        numberOfPoints: null,
     };
 
     before(() => {
@@ -101,7 +97,7 @@ context('Actions on polygon', () => {
             cy.createPolygon(createPolygonTrackPoints);
         });
 
-        it('Draw a polygon shape, track with second label.', () => {
+        it('Draw a polygon shape with second label and "Done" button, track with second label.', () => {
             cy.createPolygon(createPolygonShapeSwitchLabel);
             cy.createPolygon(createPolygonTrackSwitchLabel);
         });

--- a/tests/cypress/integration/actions_objects2/case_11_polylines_shape_track_label_points.js
+++ b/tests/cypress/integration/actions_objects2/case_11_polylines_shape_track_label_points.js
@@ -17,7 +17,6 @@ context('Actions on polylines.', () => {
             { x: 250, y: 200 },
             { x: 250, y: 250 },
         ],
-        complete: true,
     };
     const createPolylinesTrack = {
         type: 'Track',
@@ -27,7 +26,6 @@ context('Actions on polylines.', () => {
             { x: 350, y: 200 },
             { x: 350, y: 350 },
         ],
-        complete: true,
     };
     const createPolylinesShapePoints = {
         type: 'Shape',
@@ -61,7 +59,7 @@ context('Actions on polylines.', () => {
             { x: 650, y: 200 },
             { x: 650, y: 250 },
         ],
-        useDoneButton: true,
+        finishWithButton: true,
     };
     const createPolylinesTrackSwitchLabel = {
         type: 'Track',
@@ -71,7 +69,7 @@ context('Actions on polylines.', () => {
             { x: 750, y: 200 },
             { x: 750, y: 250 },
         ],
-        complete: true,
+        finishWithButton: true,
     };
 
     before(() => {
@@ -91,7 +89,7 @@ context('Actions on polylines.', () => {
             cy.createPolyline(createPolylinesTrackPoints);
         });
 
-        it('Draw a polylines shape with second label and "Done" button, track with second label.', () => {
+        it('Draw a polylines shape, track with second label and "Done" button.', () => {
             cy.createPolyline(createPolylinesShapeSwitchLabel);
             cy.createPolyline(createPolylinesTrackSwitchLabel);
         });

--- a/tests/cypress/integration/actions_objects2/case_11_polylines_shape_track_label_points.js
+++ b/tests/cypress/integration/actions_objects2/case_11_polylines_shape_track_label_points.js
@@ -6,7 +6,7 @@
 
 import { taskName, labelName } from '../../support/const';
 
-context('Actions on polylines', () => {
+context('Actions on polylines.', () => {
     const caseId = '11';
     const newLabelName = `New label for case ${caseId}`;
     const createPolylinesShape = {
@@ -18,7 +18,6 @@ context('Actions on polylines', () => {
             { x: 250, y: 250 },
         ],
         complete: true,
-        numberOfPoints: null,
     };
     const createPolylinesTrack = {
         type: 'Track',
@@ -29,7 +28,6 @@ context('Actions on polylines', () => {
             { x: 350, y: 350 },
         ],
         complete: true,
-        numberOfPoints: null,
     };
     const createPolylinesShapePoints = {
         type: 'Shape',
@@ -63,8 +61,7 @@ context('Actions on polylines', () => {
             { x: 650, y: 200 },
             { x: 650, y: 250 },
         ],
-        complete: true,
-        numberOfPoints: null,
+        useDoneButton: true,
     };
     const createPolylinesTrackSwitchLabel = {
         type: 'Track',
@@ -75,7 +72,6 @@ context('Actions on polylines', () => {
             { x: 750, y: 250 },
         ],
         complete: true,
-        numberOfPoints: null,
     };
 
     before(() => {
@@ -95,7 +91,7 @@ context('Actions on polylines', () => {
             cy.createPolyline(createPolylinesTrackPoints);
         });
 
-        it('Draw a polylines shape, track with second label.', () => {
+        it('Draw a polylines shape with second label and "Done" button, track with second label.', () => {
             cy.createPolyline(createPolylinesShapeSwitchLabel);
             cy.createPolyline(createPolylinesTrackSwitchLabel);
         });

--- a/tests/cypress/integration/actions_objects2/case_12_points_shape_track_label.js
+++ b/tests/cypress/integration/actions_objects2/case_12_points_shape_track_label.js
@@ -17,7 +17,6 @@ context('Actions on points.', () => {
             { x: 250, y: 200 },
             { x: 250, y: 250 },
         ],
-        complete: true,
     };
     const createPointsTrack = {
         type: 'Track',
@@ -27,7 +26,6 @@ context('Actions on points.', () => {
             { x: 350, y: 200 },
             { x: 350, y: 350 },
         ],
-        complete: true,
     };
     const createPointsShapePoints = {
         type: 'Shape',
@@ -61,7 +59,7 @@ context('Actions on points.', () => {
             { x: 650, y: 200 },
             { x: 650, y: 250 },
         ],
-        useDoneButton: true,
+        finishWithButton: true,
     };
     const createPointsTrackSwitchLabel = {
         type: 'Track',
@@ -71,7 +69,7 @@ context('Actions on points.', () => {
             { x: 750, y: 200 },
             { x: 750, y: 250 },
         ],
-        complete: true,
+        finishWithButton: true,
     };
 
     before(() => {
@@ -91,7 +89,7 @@ context('Actions on points.', () => {
             cy.createPoint(createPointsTrackPoints);
         });
 
-        it('Draw a points shape with second label and "Done" button, track with second label.', () => {
+        it('Draw a points shape, track with second label and "Done" button.', () => {
             cy.createPoint(createPointsShapeSwitchLabel);
             cy.createPoint(createPointsTrackSwitchLabel);
         });

--- a/tests/cypress/integration/actions_objects2/case_12_points_shape_track_label.js
+++ b/tests/cypress/integration/actions_objects2/case_12_points_shape_track_label.js
@@ -6,7 +6,7 @@
 
 import { taskName, labelName } from '../../support/const';
 
-context('Actions on points', () => {
+context('Actions on points.', () => {
     const caseId = '12';
     const newLabelName = `New label for case ${caseId}`;
     const createPointsShape = {
@@ -18,7 +18,6 @@ context('Actions on points', () => {
             { x: 250, y: 250 },
         ],
         complete: true,
-        numberOfPoints: null,
     };
     const createPointsTrack = {
         type: 'Track',
@@ -29,7 +28,6 @@ context('Actions on points', () => {
             { x: 350, y: 350 },
         ],
         complete: true,
-        numberOfPoints: null,
     };
     const createPointsShapePoints = {
         type: 'Shape',
@@ -63,8 +61,7 @@ context('Actions on points', () => {
             { x: 650, y: 200 },
             { x: 650, y: 250 },
         ],
-        complete: true,
-        numberOfPoints: null,
+        useDoneButton: true,
     };
     const createPointsTrackSwitchLabel = {
         type: 'Track',
@@ -75,7 +72,6 @@ context('Actions on points', () => {
             { x: 750, y: 250 },
         ],
         complete: true,
-        numberOfPoints: null,
     };
 
     before(() => {
@@ -85,15 +81,17 @@ context('Actions on points', () => {
     });
 
     describe(`Testing case "${caseId}"`, () => {
-        it('Draw a points shape, track', () => {
+        it('Draw a points shape, track.', () => {
             cy.createPoint(createPointsShape);
             cy.createPoint(createPointsTrack);
         });
-        it('Draw a points shape, track with use parameter "number of points"', () => {
+
+        it('Draw a points shape, track with use parameter "number of points".', () => {
             cy.createPoint(createPointsShapePoints);
             cy.createPoint(createPointsTrackPoints);
         });
-        it('Draw a points shape, track with second label', () => {
+
+        it('Draw a points shape with second label and "Done" button, track with second label.', () => {
             cy.createPoint(createPointsShapeSwitchLabel);
             cy.createPoint(createPointsTrackSwitchLabel);
         });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -304,7 +304,6 @@ Cypress.Commands.add('createPoint', (createPointParams) => {
             selectedValueGlobal = $labelValue.text();
         });
         if (createPointParams.numberOfPoints) {
-            createPointParams.complete = false;
             cy.get('.ant-input-number-input').clear().type(createPointParams.numberOfPoints);
         }
         cy.contains('button', createPointParams.type).click();
@@ -312,14 +311,15 @@ Cypress.Commands.add('createPoint', (createPointParams) => {
     createPointParams.pointsMap.forEach((element) => {
         cy.get('.cvat-canvas-container').click(element.x, element.y);
     });
-    if (createPointParams.useDoneButton) {
+    if (createPointParams.finishWithButton) {
         cy.contains('span', 'Done').click();
-    }
-    if (createPointParams.complete) {
-        const keyCodeN = 78;
-        cy.get('.cvat-canvas-container')
-            .trigger('keydown', { keyCode: keyCodeN })
-            .trigger('keyup', { keyCode: keyCodeN });
+    } else {
+        if (! createPointParams.numberOfPoints) {
+            const keyCodeN = 78;
+            cy.get('.cvat-canvas-container')
+                .trigger('keydown', { keyCode: keyCodeN })
+                .trigger('keyup', { keyCode: keyCodeN });
+        }
     }
     cy.checkObjectParameters(createPointParams, 'POINTS');
 });
@@ -351,7 +351,7 @@ Cypress.Commands.add('createPolygon', (createPolygonParams) => {
                 selectedValueGlobal = $labelValue.text();
             });
             if (createPolygonParams.numberOfPoints) {
-                createPolygonParams.complete = false;
+                createPolygonParams.finishWithHotkey = false;
                 cy.get('.ant-input-number-input').clear().type(createPolygonParams.numberOfPoints);
             }
             cy.contains('button', createPolygonParams.type).click();
@@ -360,14 +360,15 @@ Cypress.Commands.add('createPolygon', (createPolygonParams) => {
     createPolygonParams.pointsMap.forEach((element) => {
         cy.get('.cvat-canvas-container').click(element.x, element.y);
     });
-    if (createPolygonParams.useDoneButton) {
+    if (createPolygonParams.finishWithButton) {
         cy.contains('span', 'Done').click();
-    }
-    if (createPolygonParams.complete) {
-        const keyCodeN = 78;
-        cy.get('.cvat-canvas-container')
-            .trigger('keydown', { keyCode: keyCodeN })
-            .trigger('keyup', { keyCode: keyCodeN });
+    } else {
+        if (! createPolygonParams.numberOfPoints) {
+            const keyCodeN = 78;
+            cy.get('.cvat-canvas-container')
+                .trigger('keydown', { keyCode: keyCodeN })
+                .trigger('keyup', { keyCode: keyCodeN });
+        }
     }
     cy.checkObjectParameters(createPolygonParams, 'POLYGON');
 });
@@ -496,7 +497,7 @@ Cypress.Commands.add('createPolyline', (createPolylineParams) => {
             selectedValueGlobal = $labelValue.text();
         });
         if (createPolylineParams.numberOfPoints) {
-            createPolylineParams.complete = false;
+            createPolylineParams.finishWithHotkey = false;
             cy.get('.ant-input-number-input').clear().type(createPolylineParams.numberOfPoints);
         }
         cy.contains('button', createPolylineParams.type).click();
@@ -504,14 +505,15 @@ Cypress.Commands.add('createPolyline', (createPolylineParams) => {
     createPolylineParams.pointsMap.forEach((element) => {
         cy.get('.cvat-canvas-container').click(element.x, element.y);
     });
-    if (createPolylineParams.useDoneButton) {
+    if (createPolylineParams.finishWithButton) {
         cy.contains('span', 'Done').click();
-    }
-    if (createPolylineParams.complete) {
-        const keyCodeN = 78;
-        cy.get('.cvat-canvas-container')
-            .trigger('keydown', { keyCode: keyCodeN })
-            .trigger('keyup', { keyCode: keyCodeN });
+    } else {
+        if (! createPolylineParams.numberOfPoints) {
+            const keyCodeN = 78;
+            cy.get('.cvat-canvas-container')
+                .trigger('keydown', { keyCode: keyCodeN })
+                .trigger('keyup', { keyCode: keyCodeN });
+        }
     }
     cy.checkObjectParameters(createPolylineParams, 'POLYLINE');
 });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -312,6 +312,9 @@ Cypress.Commands.add('createPoint', (createPointParams) => {
     createPointParams.pointsMap.forEach((element) => {
         cy.get('.cvat-canvas-container').click(element.x, element.y);
     });
+    if (createPointParams.useDoneButton) {
+        cy.contains('span', 'Done').click();
+    }
     if (createPointParams.complete) {
         const keyCodeN = 78;
         cy.get('.cvat-canvas-container')
@@ -357,6 +360,9 @@ Cypress.Commands.add('createPolygon', (createPolygonParams) => {
     createPolygonParams.pointsMap.forEach((element) => {
         cy.get('.cvat-canvas-container').click(element.x, element.y);
     });
+    if (createPolygonParams.useDoneButton) {
+        cy.contains('span', 'Done').click();
+    }
     if (createPolygonParams.complete) {
         const keyCodeN = 78;
         cy.get('.cvat-canvas-container')
@@ -498,6 +504,9 @@ Cypress.Commands.add('createPolyline', (createPolylineParams) => {
     createPolylineParams.pointsMap.forEach((element) => {
         cy.get('.cvat-canvas-container').click(element.x, element.y);
     });
+    if (createPolylineParams.useDoneButton) {
+        cy.contains('span', 'Done').click();
+    }
     if (createPolylineParams.complete) {
         const keyCodeN = 78;
         cy.get('.cvat-canvas-container')

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -351,7 +351,6 @@ Cypress.Commands.add('createPolygon', (createPolygonParams) => {
                 selectedValueGlobal = $labelValue.text();
             });
             if (createPolygonParams.numberOfPoints) {
-                createPolygonParams.finishWithHotkey = false;
                 cy.get('.ant-input-number-input').clear().type(createPolygonParams.numberOfPoints);
             }
             cy.contains('button', createPolygonParams.type).click();
@@ -497,7 +496,6 @@ Cypress.Commands.add('createPolyline', (createPolylineParams) => {
             selectedValueGlobal = $labelValue.text();
         });
         if (createPolylineParams.numberOfPoints) {
-            createPolylineParams.finishWithHotkey = false;
             cy.get('.ant-input-number-input').clear().type(createPolylineParams.numberOfPoints);
         }
         cy.contains('button', createPolylineParams.type).click();


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Updating tests for drawing points, polygons, and polylines. Added the use of the "Done" button when drawing shapes.
PR #3417 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
