### PR TITLE
Cypress test. Update case 14. "Selected opacity" level of shapes being drawn.

### DIFF
--- a/tests/cypress/integration/actions_objects2/case_14_appearance_features.js
+++ b/tests/cypress/integration/actions_objects2/case_14_appearance_features.js
@@ -78,6 +78,7 @@ context('Appearance features', () => {
             cy.createCuboid(createCuboidShape2Points);
             cy.createPoint(createPointsShape);
         });
+
         it('Set opacity level for shapes to 100. All shapes are filled.', () => {
             cy.get('.cvat-appearance-opacity-slider')
                 .click('right')
@@ -101,7 +102,8 @@ context('Appearance features', () => {
                     });
             });
         });
-        it('Set selected opacity to 0.', () => {
+
+        it('Set "Selected opacity" to 0.', () => {
             cy.get('.cvat-appearance-selected-opacity-slider')
                 .click('left')
                 .within(() => {
@@ -113,7 +115,8 @@ context('Appearance features', () => {
                         });
                 });
         });
-        it('Activate the box, the polygon and the cuboid. Boxes are transparent during activated.', () => {
+
+        it('Activate the rectangle, the polygon and the cuboid. Shapes are transparent during activated.', () => {
             for (const i of ['#cvat_canvas_shape_1', '#cvat_canvas_shape_2', '#cvat_canvas_shape_4']) {
                 cy.get(i)
                     .trigger('mousemove')
@@ -121,10 +124,9 @@ context('Appearance features', () => {
                     .and('have.css', 'fill-opacity', ariaValuenow);
             }
         });
-        it('Activate checkbox "show projections".', () => {
+
+        it('Activate checkbox "show projections". Activated the cuboid. Projection lines are visible.', () => {
             cy.get('.cvat-appearance-cuboid-projections-checkbox').click();
-        });
-        it('Activated the cuboid. Projection lines are visible.', () => {
             cy.get('#cvat_canvas_shape_4')
                 .trigger('mousemove', { force: true })
                 .should('have.attr', 'projections', 'true');
@@ -132,6 +134,7 @@ context('Appearance features', () => {
             // Deactivate all objects
             cy.get('.cvat-canvas-container').click(500, 500);
         });
+
         it('Activate checkbox "outlined borders" with a red color. The borders are red on the objects.', () => {
             cy.get('.cvat-appearance-outlinded-borders-checkbox').click();
             cy.get('.cvat-appearance-outlined-borders-button').click();
@@ -140,12 +143,14 @@ context('Appearance features', () => {
                 cy.get(object).should('have.attr', 'stroke', `#${strokeColor}`);
             });
         });
+
         it('Set "Color by" to instance. The shapes changed a color.', () => {
             cy.changeAppearance('Instance');
             cy.get('.cvat_canvas_shape').each((object) => {
                 cy.get(object).should('have.css', 'fill').and('not.equal', fill);
             });
         });
+
         it('Set "Color by" to group. The shapes are white.', () => {
             cy.changeAppearance('Group');
             cy.get('.cvat_canvas_shape').each((object) => {
@@ -161,6 +166,17 @@ context('Appearance features', () => {
             // Disable "Outlined borders" and check css "stroke" for polyline.
             cy.get('.cvat-appearance-outlinded-borders-checkbox').click();
             cy.get('#cvat_canvas_shape_3').should('have.css', 'stroke', 'rgb(224, 224, 224)'); // have CSS property stroke with the value rgb(224, 224, 224)
+        });
+
+        it('"Selected opacity" slider now defines opacity level of shapes being drawn.', () => {
+            cy.interactControlButton('draw-rectangle');
+            cy.get('.cvat-draw-rectangle-popover-visible').contains('button', 'Shape').click();
+            cy.get('.cvat-canvas-container')
+                .click(createRectangleShape2Points.firstX, createRectangleShape2Points.firstY + 400);
+            cy.get('.cvat_canvas_shape_drawing').should('have.attr', 'fill-opacity', 0);
+            cy.get('.cvat-appearance-selected-opacity-slider').click('right')
+            cy.get('.cvat_canvas_shape_drawing').should('have.attr', 'fill-opacity', 1);
+            cy.get('body').type('{Esc}');
         });
     });
 });

--- a/tests/cypress/integration/actions_objects2/case_14_appearance_features.js
+++ b/tests/cypress/integration/actions_objects2/case_14_appearance_features.js
@@ -169,14 +169,75 @@ context('Appearance features', () => {
         });
 
         it('"Selected opacity" slider now defines opacity level of shapes being drawn.', () => {
-            cy.interactControlButton('draw-rectangle');
-            cy.get('.cvat-draw-rectangle-popover-visible').contains('button', 'Shape').click();
-            cy.get('.cvat-canvas-container')
-                .click(createRectangleShape2Points.firstX, createRectangleShape2Points.firstY + 400);
-            cy.get('.cvat_canvas_shape_drawing').should('have.attr', 'fill-opacity', 0);
-            cy.get('.cvat-appearance-selected-opacity-slider').click('right')
-            cy.get('.cvat_canvas_shape_drawing').should('have.attr', 'fill-opacity', 1);
-            cy.get('body').type('{Esc}');
+            function testDrawShapeCheckOpacity({ shape, drawingMethod, shapeType, fillOpacityBefore, fillOpacityAfter, opacityBefore, opacityAfter }) {
+                cy.interactControlButton(`draw-${shape}`);
+                cy.get(`.cvat-draw-${shape}-popover-visible`).within(() => {
+                    if (drawingMethod) {
+                        cy.contains('.ant-radio-wrapper', drawingMethod).click();
+                    }
+                    cy.contains('button', shapeType).click();
+                });
+                cy.get('.cvat-canvas-container').click(100, 450);
+                if (fillOpacityBefore != null || fillOpacityAfter != null) {
+                    cy.get('.cvat-appearance-selected-opacity-slider').click('left');
+                    cy.get('.cvat_canvas_shape_drawing').should('have.attr', 'fill-opacity', fillOpacityBefore);
+                    cy.get('.cvat-appearance-selected-opacity-slider').click('right');
+                    cy.get('.cvat_canvas_shape_drawing').should('have.attr', 'fill-opacity', fillOpacityAfter);
+                } else if (opacityBefore != null || opacityAfter != null) {
+                    cy.get('.cvat-appearance-selected-opacity-slider').click('left');
+                    cy.get('.cvat_canvas_shape_drawing').should('have.attr', 'opacity', opacityBefore);
+                    cy.get('.cvat-appearance-selected-opacity-slider').click('right');
+                    cy.get('.cvat_canvas_shape_drawing').should('have.attr', 'opacity', opacityAfter);
+                } else {
+                    cy.get('.cvat_canvas_shape_drawing').should('not.have.attr', 'opacity');
+                    cy.get('.cvat_canvas_shape_drawing').should('not.have.attr', 'fill-opacity');
+                }
+                cy.get('body').type('{Esc}');
+            }
+            // affect opacity level
+            testDrawShapeCheckOpacity({
+                shape: 'rectangle',
+                drawingMethod: 'By 2 Points',
+                shapeType: 'Shape',
+                fillOpacityBefore: 0,
+                fillOpacityAfter: 1,
+            });
+            // not affect opacity level
+            testDrawShapeCheckOpacity({
+                shape: 'rectangle',
+                drawingMethod: 'By 4 Points',
+                shapeType: 'Shape',
+                opacityBefore: 0,
+                opacityAfter: 0,
+            });
+            // not affect opacity level
+            testDrawShapeCheckOpacity({
+                shape: 'polyline',
+                shapeType: 'Shape',
+                fillOpacityBefore: 0,
+                fillOpacityAfter: 0,
+            });
+            // not affect opacity level
+            testDrawShapeCheckOpacity({
+                shape: 'points',
+                shapeType: 'Shape',
+                opacityBefore: 0,
+                opacityAfter: 0,
+            });
+            // affect opacity level
+            testDrawShapeCheckOpacity({
+                shape: 'cuboid',
+                drawingMethod: 'From rectangle',
+                shapeType: 'Shape',
+                fillOpacityBefore: 0,
+                fillOpacityAfter: 1,
+            });
+            // not have 'fill-opacity' or 'opacity' attributes
+            testDrawShapeCheckOpacity({
+                shape: 'cuboid',
+                drawingMethod: 'By 4 Points',
+                shapeType: 'Shape',
+            });
         });
     });
 });

--- a/tests/cypress/integration/actions_objects2/case_14_appearance_features.js
+++ b/tests/cypress/integration/actions_objects2/case_14_appearance_features.js
@@ -217,6 +217,13 @@ context('Appearance features', () => {
                 fillOpacityBefore: 0,
                 fillOpacityAfter: 0,
             });
+            // affect opacity level
+            testDrawShapeCheckOpacity({
+                shape: 'polygon',
+                shapeType: 'Shape',
+                fillOpacityBefore: 0,
+                fillOpacityAfter: 1,
+            });
             // not affect opacity level
             testDrawShapeCheckOpacity({
                 shape: 'points',

--- a/tests/cypress/integration/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/integration/actions_tasks2/case_101_opencv_basic_actions.js
@@ -84,6 +84,10 @@ context('OpenCV. Intelligent cissors. Histogram Equalization.', () => {
                     expect(intermediateShapeNumberPointsBeforeChange).to.be.lt(intermediateShapeNumberPointsAfterChange);
                 });
             });
+            cy.get('.cvat-appearance-selected-opacity-slider').click('left');
+            cy.get('.cvat_canvas_interact_intermediate_shape').should('have.attr', 'fill-opacity', 0);
+            cy.get('.cvat-appearance-selected-opacity-slider').click('right');
+            cy.get('.cvat_canvas_interact_intermediate_shape').should('have.attr', 'fill-opacity', 1);
             cy.get('body').type('{Esc}'); // Cancel drawing
             cy.get('.cvat_canvas_interact_intermediate_shape').should('not.exist');
             cy.get('.cvat_canvas_shape').should('have.length', 2);


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Cypress test for "Selected opacity" slider now defines opacity level of shapes being drawn. PR #3473 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
