### PR TITLE
Add arguments to cli to disabling copying image data in share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added ability to import data from share with cli without copying the data (<https://github.com/openvinotoolkit/cvat/issues/2862>)
 - Notification if the browser does not support nesassary API
 - Added ability to export project as a dataset (<https://github.com/openvinotoolkit/cvat/pull/3365>)
 - Additional inline tips in interactors with demo gifs (<https://github.com/openvinotoolkit/cvat/pull/3473>)

--- a/utils/cli/core/core.py
+++ b/utils/cli/core/core.py
@@ -41,6 +41,10 @@ class CLI():
             data['image_quality'] = kwargs.get('image_quality')
         if 'frame_step' in kwargs:
             data['frame_filter'] = f"step={kwargs.get('frame_step')}"
+        if 'copy_data' in kwargs:
+            data['copy_data'] = kwargs.get('copy_data')
+        if 'use_cache' in kwargs:
+            data['use_cache'] = kwargs.get('use_cache')
 
         response = self.session.post(url, data=data, files=files)
         response.raise_for_status()

--- a/utils/cli/core/definition.py
+++ b/utils/cli/core/definition.py
@@ -195,6 +195,19 @@ task_create_parser.add_argument(
     help='''set the frame step option in the advanced configuration
             when uploading image series or videos (default: %(default)s)'''
 )
+task_create_parser.add_argument(
+    '--copy_data',
+    default=False,
+    action='store_true',
+    help='''set the option to copy the data, only used when resource type is
+            share (default: %(default)s)'''
+)
+task_create_parser.add_argument(
+    '--use_cache',
+    default=True,
+    action='store_false',
+    help='''set the option to use the cache (default: %(default)s)'''
+)
 #######################################################################
 # Delete
 #######################################################################


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->
When importing data into CVAT from the share mount the user can uncheck `copy_data` and check `use_cache` to avoid creating multiple copies of the data on the server, this functionality wasn't available in the cli.  So I added it.  It was previously proposed in #2862 and is under the backlog of the project planning as work to be completed [here](https://github.com/openvinotoolkit/cvat/projects/20)


### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
When a user downloads images to their CVAT server, then imports into the CVAT application, it is not memory efficient to make 3 copies of the image (raw, original, and compressed) - this functionality allows the user to disable creating these copies.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I imported images with the code changes and verified that by default it does not cause the images to be duplicated and the hard drive space does not fill up nearly as rapidly.  Issue #3542 goes into greater detail of copied file location as seen during testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
