### PR TITLE
Update Cypress test to cover "Intelligent scissors blocking feature".

### DIFF
--- a/tests/cypress/integration/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/integration/actions_tasks2/case_101_opencv_basic_actions.js
@@ -64,7 +64,7 @@ context('OpenCV. Intelligent cissors. Histogram Equalization.', () => {
             cy.opencvCreateShape(createOpencvShapeSecondLabel);
         });
 
-        it('Change the number of points when the shape is drawn. Cancel drawing.', () => {
+        it('Change the number of points when the shape is drawn. Intelligent scissors blocking feature. Cancel drawing.', () => {
             openOpencvControlPopover();
             cy.get('.cvat-opencv-drawing-tool').click();
             pointsMap.forEach((element) => {
@@ -88,6 +88,12 @@ context('OpenCV. Intelligent cissors. Histogram Equalization.', () => {
             cy.get('.cvat_canvas_interact_intermediate_shape').should('have.attr', 'fill-opacity', 0);
             cy.get('.cvat-appearance-selected-opacity-slider').click('right');
             cy.get('.cvat_canvas_interact_intermediate_shape').should('have.attr', 'fill-opacity', 1);
+            // Intelligent scissors blocking feature
+            cy.get('.cvat_canvas_threshold').should('exist');
+            cy.contains('span', 'Block').click();
+            cy.get('.cvat_canvas_threshold').should('not.exist');
+            cy.contains('span', 'Block').click();
+            cy.get('.cvat_canvas_threshold').should('exist');
             cy.get('body').type('{Esc}'); // Cancel drawing
             cy.get('.cvat_canvas_interact_intermediate_shape').should('not.exist');
             cy.get('.cvat_canvas_shape').should('have.length', 2);

--- a/tests/cypress/integration/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/integration/actions_tasks2/case_101_opencv_basic_actions.js
@@ -64,7 +64,7 @@ context('OpenCV. Intelligent cissors. Histogram Equalization.', () => {
             cy.opencvCreateShape(createOpencvShapeSecondLabel);
         });
 
-        it('Change the number of points when the shape is drawn. Intelligent scissors blocking feature. Cancel drawing.', () => {
+        it('Change the number of points when the shape is drawn. Cancel drawing.', () => {
             openOpencvControlPopover();
             cy.get('.cvat-opencv-drawing-tool').click();
             pointsMap.forEach((element) => {
@@ -73,6 +73,8 @@ context('OpenCV. Intelligent cissors. Histogram Equalization.', () => {
             cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
                 // Get count of points
                 const intermediateShapeNumberPointsBeforeChange = intermediateShape.attr('points').split(' ').length;
+                // expected 7 to be above 5
+                expect(intermediateShapeNumberPointsBeforeChange).to.be.gt(pointsMap.length);
                 // Change number of points
                 cy.get('.cvat-approx-poly-threshold-wrapper')
                     .find('[role="slider"]')
@@ -88,15 +90,28 @@ context('OpenCV. Intelligent cissors. Histogram Equalization.', () => {
             cy.get('.cvat_canvas_interact_intermediate_shape').should('have.attr', 'fill-opacity', 0);
             cy.get('.cvat-appearance-selected-opacity-slider').click('right');
             cy.get('.cvat_canvas_interact_intermediate_shape').should('have.attr', 'fill-opacity', 1);
-            // Intelligent scissors blocking feature
-            cy.get('.cvat_canvas_threshold').should('exist');
-            cy.contains('span', 'Block').click();
-            cy.get('.cvat_canvas_threshold').should('not.exist');
-            cy.contains('span', 'Block').click();
-            cy.get('.cvat_canvas_threshold').should('exist');
             cy.get('body').type('{Esc}'); // Cancel drawing
             cy.get('.cvat_canvas_interact_intermediate_shape').should('not.exist');
             cy.get('.cvat_canvas_shape').should('have.length', 2);
+        });
+
+        it('Check "Intelligent scissors blocking feature". Cancel drawing.', () => {
+            openOpencvControlPopover();
+            cy.get('.cvat-opencv-drawing-tool').click();
+            cy.contains('span', 'Block').click();
+            cy.get('.cvat_canvas_threshold').should('not.exist');
+            pointsMap.forEach((element) => {
+                cy.get('.cvat-canvas-container').click(element.x, element.y);
+            });
+            cy.get('.cvat_canvas_interact_intermediate_shape').then((intermediateShape) => {
+                // Get count of points
+                const intermediateShapeNumberPoints = intermediateShape.attr('points').split(' ').length;
+                // The last point on the crosshair
+                expect(intermediateShapeNumberPoints - 1).to.be.equal(pointsMap.length)
+            });
+            cy.get('body').type('{Ctrl}'); // Checking hotkey
+            cy.get('.cvat_canvas_threshold').should('exist');
+            cy.get('body').type('{Esc}'); // Cancel drawing
         });
 
         it('Check "Histogram Equalization" feature.', () => {


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Update Cypress test to check "Intelligent scissors blocking feature". PR #3510 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
