### PR TITLE
Cypress. Fix case "OpenCV. Intelligent scissors. Histogram Equalization" for Firefox.

### DIFF
--- a/tests/cypress/integration/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/integration/actions_tasks2/case_101_opencv_basic_actions.js
@@ -84,10 +84,22 @@ context('OpenCV. Intelligent cissors. Histogram Equalization.', () => {
                     expect(intermediateShapeNumberPointsBeforeChange).to.be.lt(intermediateShapeNumberPointsAfterChange);
                 });
             });
-            cy.get('.cvat-appearance-selected-opacity-slider').click('left');
-            cy.get('.cvat_canvas_interact_intermediate_shape').should('have.attr', 'fill-opacity', 0);
-            cy.get('.cvat-appearance-selected-opacity-slider').click('right');
-            cy.get('.cvat_canvas_interact_intermediate_shape').should('have.attr', 'fill-opacity', 1);
+            cy.get('.cvat-appearance-selected-opacity-slider')
+                .click('left')
+                .find('[role="slider"]')
+                .then((sliderSelectedOpacityLeft) => {
+                    const sliderSelectedOpacityValuenow = sliderSelectedOpacityLeft.attr('aria-valuenow');
+                    cy.get('.cvat_canvas_interact_intermediate_shape')
+                        .should('have.attr', 'fill-opacity', sliderSelectedOpacityValuenow / 100);
+            });
+            cy.get('.cvat-appearance-selected-opacity-slider')
+                .click('right')
+                .find('[role="slider"]')
+                .then((sliderSelectedOpacityRight) => {
+                    const sliderSelectedOpacityValuenow = sliderSelectedOpacityRight.attr('aria-valuenow');
+                    cy.get('.cvat_canvas_interact_intermediate_shape')
+                        .should('have.attr', 'fill-opacity', sliderSelectedOpacityValuenow / 100);
+            });
             cy.get('body').type('{Esc}'); // Cancel drawing
             cy.get('.cvat_canvas_interact_intermediate_shape').should('not.exist');
             cy.get('.cvat_canvas_shape').should('have.length', 2);

--- a/tests/cypress/integration/actions_tasks2/case_101_opencv_basic_actions.js
+++ b/tests/cypress/integration/actions_tasks2/case_101_opencv_basic_actions.js
@@ -7,7 +7,7 @@
 import { taskName, labelName } from '../../support/const';
 import { generateString } from '../../support/utils';
 
-context('OpenCV. Intelligent cissors. Histogram Equalization.', () => {
+context('OpenCV. Intelligent scissors. Histogram Equalization.', () => {
     const caseId = '101';
     const newLabel = `Case ${caseId}`
     const createOpencvShape = {


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Fixing the test fail in Firefox browser.
https://github.com/openvinotoolkit/cvat/actions/runs/1148654935

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
