### PR TITLE
Update launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,7 +59,7 @@
         },
         {
             "name": "server: chrome",
-            "type": "node",
+            "type": "pwa-chrome",
             "request": "launch",
             "url": "http://localhost:7000/",
             "disableNetworkCache":true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "node",
+            "type": "pwa-chrome",
             "request": "launch",
             "preLaunchTask": "npm: start - cvat-ui",
             "name": "ui.js: debug",
@@ -22,7 +22,7 @@
             "smartStep": true,
         },
         {
-            "type": "node",
+            "type": "pwa-chrome",
             "request": "launch",
             "name": "ui.js: test",
             "cwd": "${workspaceRoot}/tests",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "chrome",
+            "type": "node",
             "request": "launch",
             "preLaunchTask": "npm: start - cvat-ui",
             "name": "ui.js: debug",
@@ -59,7 +59,7 @@
         },
         {
             "name": "server: chrome",
-            "type": "chrome",
+            "type": "node",
             "request": "launch",
             "url": "http://localhost:7000/",
             "disableNetworkCache":true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
             "smartStep": true,
         },
         {
-            "type": "pwa-chrome",
+            "type": "node",
             "request": "launch",
             "name": "ui.js: test",
             "cwd": "${workspaceRoot}/tests",


### PR DESCRIPTION
Changed .vscode\launch.json for compatibility issues.


Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT


### Motivation and context
Fixed [[#3525]](https://github.com/openvinotoolkit/cvat/issues/3525)
Chrome debugger for vs-code is deprecated now, so we should move to the JavaScript Debugger

### How has this been tested?
All tests were passed while testing in JavaScript Workflow

### Checklist

- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [x] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)


