### PR TITLE
Remove save interpolated shapes

### DIFF
--- a/cvat/apps/dataset_manager/annotation.py
+++ b/cvat/apps/dataset_manager/annotation.py
@@ -110,9 +110,6 @@ class AnnotationIR:
                         interpolated_shapes[stop + 1]['outside']:
                     segment_shapes.append(interpolated_shapes[stop + 1])
 
-            # Should delete 'interpolation_shapes' and 'keyframe' keys because
-            # Track and TrackedShape models don't expect these fields
-            del track['interpolated_shapes']
             for shape in segment_shapes:
                 shape.pop('keyframe', None)
 
@@ -429,15 +426,6 @@ class TrackManager(ObjectManager):
             shape["frame"] = end_frame
             shape["outside"] = True
             obj["shapes"].append(shape)
-            # Need to update cached interpolated shapes
-            # because key shapes were changed
-            if obj.get("interpolated_shapes"):
-                last_interpolated_shape = obj["interpolated_shapes"][-1]
-                for frame in range(last_interpolated_shape["frame"] + 1, end_frame):
-                    last_interpolated_shape = deepcopy(last_interpolated_shape)
-                    last_interpolated_shape["frame"] = frame
-                    obj["interpolated_shapes"].append(last_interpolated_shape)
-                obj["interpolated_shapes"].append(shape)
 
     @staticmethod
     def get_interpolated_shapes(track, start_frame, end_frame):
@@ -713,9 +701,6 @@ class TrackManager(ObjectManager):
 
             return shapes
 
-        if track.get("interpolated_shapes"):
-            return track["interpolated_shapes"]
-
         shapes = []
         curr_frame = track["shapes"][0]["frame"]
         prev_shape = {}
@@ -742,8 +727,6 @@ class TrackManager(ObjectManager):
             shape["frame"] = end_frame
             shapes.extend(interpolate(prev_shape, shape))
 
-        track["interpolated_shapes"] = shapes
-
         return shapes
 
     @staticmethod
@@ -760,6 +743,5 @@ class TrackManager(ObjectManager):
 
         track["frame"] = min(obj0["frame"], obj1["frame"])
         track["shapes"] = list(sorted(shapes.values(), key=lambda shape: shape["frame"]))
-        track["interpolated_shapes"] = []
 
         return track


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
The function `get_intepolated_shapes` saves all interpolated shapes for each track. And they can take up a lot of RAM.
At the same time, cached shapes are not used anywhere.
Therefore, they can be removed without consequences.
Fixed #3456.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~[ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
