### PR TITLE
Add note about redis server in wsl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed dextr deployment (<https://github.com/openvinotoolkit/cvat/pull/3820>)
 - Migration of `dataset_repo` application (<https://github.com/openvinotoolkit/cvat/pull/3827>)
 - Helm settings for external psql database were unused by backend (<https://github.com/openvinotoolkit/cvat/pull/3779>)
+- Updated WSL setup for development (<https://github.com/openvinotoolkit/cvat/pull/3828>)
 
 ### Security
 

--- a/site/content/en/docs/contributing/development-environment.md
+++ b/site/content/en/docs/contributing/development-environment.md
@@ -110,3 +110,6 @@ You develop CVAT under WSL (Windows subsystem for Linux) following next steps.
   ```
 
 - Run all commands from this installation guide in WSL Ubuntu shell.
+- You might have to manually start the redis server in wsl before you can start the configuration inside
+  Visual Studio Code. You can do this with `sudo service redis-server start`. Alternatively you can also
+  use a redis docker image instead of using the redis-server locally.


### PR DESCRIPTION
This change adds a note about manually starting the redis server inside wsl. This is necessary because installing the redis-server package does not start it when systemd is not available.

### Motivation and context
Multiple people ran into this problem and reported it on gitter.  Also it's not obvious that you have to start it manually.

### How has this been tested?
Manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [x] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
~~- [ ] I have added tests to cover my changes~~
~~- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
~~- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)
