### PR TITLE
Support automatic tag annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add project tasks paginations (<https://github.com/openvinotoolkit/cvat/pull/3910>)
 - Add remove issue button (<https://github.com/openvinotoolkit/cvat/pull/3952>)
 - Options to change font size & position of text labels on the canvas (<https://github.com/openvinotoolkit/cvat/pull/3972>)
+- Add "tag" return type for automatic annotation in Nuclio (<https://github.com/openvinotoolkit/cvat/pull/3896>)
 
 ### Changed
 - TDB
@@ -48,7 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a tutorial on attaching cloud storage AWS-S3 (<https://github.com/openvinotoolkit/cvat/pull/3745>)
   and Azure Blob Container (<https://github.com/openvinotoolkit/cvat/pull/3778>)
 - The feature to remove annotations in a specified range of frames (<https://github.com/openvinotoolkit/cvat/pull/3617>)
-- Add "tag" return type for automatic annotation in Nuclio (<https://github.com/openvinotoolkit/cvat/pull/3896>)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a tutorial on attaching cloud storage AWS-S3 (<https://github.com/openvinotoolkit/cvat/pull/3745>)
   and Azure Blob Container (<https://github.com/openvinotoolkit/cvat/pull/3778>)
 - The feature to remove annotations in a specified range of frames (<https://github.com/openvinotoolkit/cvat/pull/3617>)
+- Add "tag" return type for automatic annotation in Nuclio (<https://github.com/openvinotoolkit/cvat/pull/3896>)
 
 ### Changed
 

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -353,6 +353,9 @@ class LambdaJob:
             def append_shape(self, shape):
                 self.data["shapes"].append(shape)
 
+            def append_tag(self, tag):
+                self.data["tags"].append(tag)
+
             def submit(self):
                 if not self.is_empty():
                     serializer = LabeledDataSerializer(data=self.data)
@@ -380,7 +383,17 @@ class LambdaJob:
 
             for anno in annotations:
                 label_id = labels.get(anno["label"])
-                if label_id is not None:
+                if label_id is None:
+                    continue # Invalid tag provided
+                if anno["type"].lower() == "tag":
+                    results.append_tag({
+                        "frame": frame,
+                        "label_id": label_id,
+                        "source": "auto",
+                        "attributes": [],
+                        "group": None,
+                    })
+                else:
                     results.append_shape({
                         "frame": frame,
                         "label_id": label_id,

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -384,7 +384,7 @@ class LambdaJob:
             for anno in annotations:
                 label_id = labels.get(anno["label"])
                 if label_id is None:
-                    continue # Invalid tag provided
+                    continue # Invalid label provided
                 if anno["type"].lower() == "tag":
                     results.append_tag({
                         "frame": frame,


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

resolves #3358 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

I have a full-frame classifier nuclio lambda and needed a way to save these tags.

* I ran the code in development using `docker-compose -f docker-compose.yml -f components/serverless/docker-compose.serverless.yml up -d`
* Invoke my nuclio classifier from the task summary page (full video) and from the annotator (single frame)
* See new tags appear in the UI.

I did see that the author of #3358 has included confidence values, which I do not believe are supported by tags. If I should support this somewhere, please LMK.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] ~~I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly~~ I do not see any documentation about what response types are supported for nuclio functions, so I don't think there's any documentation to update.  New documentation could be added about the general capabilities of this feature, but it seems out of scope for this PR.
- [ ] ~~I have added tests to cover my changes~~ I do not see tests related to this section of the code.  If they exist, please LMK and I'll add coverage.
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] ~~I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~ Not applicable

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] ~~I have updated the license header for each file (see an example below)~~ No new files added

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
