### PR TITLE
Add FiftyOne to partners list

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ connection with your use of FFmpeg.
 - [Human Protocol](https://hmt.ai) uses CVAT as a way of adding annotation service to the human protocol.
 - [Cogito Tech LLC](https://bit.ly/3klT0h6), a Human-in-the-Loop Workforce Solutions Provider, used CVAT
   in annotation of about 5,000 images for a brand operating in the fashion segment.
+- [FiftyOne](https://fiftyone.ai) is an open-source dataset curation and model analysis tool for visualizing, exploring, and improving computer vision datasets and models that is [tightly integrated](https://voxel51.com/docs/fiftyone/integrations/cvat.html) with CVAT for annotation and label refinement.
+
+<a href="https://fiftyone.ai"><img src="https://user-images.githubusercontent.com/21222883/143083891-a75d9fba-2829-43b1-ac07-bd46860964b2.png" height="500" width="700" ></a>
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -144,8 +144,6 @@ connection with your use of FFmpeg.
   in annotation of about 5,000 images for a brand operating in the fashion segment.
 - [FiftyOne](https://fiftyone.ai) is an open-source dataset curation and model analysis tool for visualizing, exploring, and improving computer vision datasets and models that is [tightly integrated](https://voxel51.com/docs/fiftyone/integrations/cvat.html) with CVAT for annotation and label refinement.
 
-<a href="https://fiftyone.ai"><img src="https://user-images.githubusercontent.com/21222883/143083891-a75d9fba-2829-43b1-ac07-bd46860964b2.png" height="500" width="700" ></a>
-
 ## Questions
 
 CVAT usage related questions or unclear concepts can be posted in our

--- a/README.md
+++ b/README.md
@@ -142,7 +142,10 @@ connection with your use of FFmpeg.
 - [Human Protocol](https://hmt.ai) uses CVAT as a way of adding annotation service to the human protocol.
 - [Cogito Tech LLC](https://bit.ly/3klT0h6), a Human-in-the-Loop Workforce Solutions Provider, used CVAT
   in annotation of about 5,000 images for a brand operating in the fashion segment.
-- [FiftyOne](https://fiftyone.ai) is an open-source dataset curation and model analysis tool for visualizing, exploring, and improving computer vision datasets and models that is [tightly integrated](https://voxel51.com/docs/fiftyone/integrations/cvat.html) with CVAT for annotation and label refinement.
+- [FiftyOne](https://fiftyone.ai) is an open-source dataset curation and model analysis
+tool for visualizing, exploring, and improving computer vision datasets and models that is
+[tightly integrated](https://voxel51.com/docs/fiftyone/integrations/cvat.html) with CVAT
+for annotation and label refinement.
 
 ## Questions
 


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

### Motivation and context

Adds the integration between [FiftyOne](https://fiftyone.ai) and CVAT to the Partners section of the README.



### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
