### PR TITLE
Cypress. Update case 105. Add check "Google cloud storage" provider fields.

### DIFF
--- a/tests/cypress/integration/actions_tasks3/case_105_cloud_storage.js
+++ b/tests/cypress/integration/actions_tasks3/case_105_cloud_storage.js
@@ -84,7 +84,7 @@ context('Cloud storage.', () => {
                 .get('.cvat-cloud-storage-region-creator')
                 .should('be.visible')
                 .within(() => {
-                    cy.contains('button', 'Add region').click()
+                    cy.contains('button', 'Add region').click();
                 });
             cy.get('.cvat-incorrect-add-region-notification').should('exist');
             cy.closeNotification('.cvat-incorrect-add-region-notification');

--- a/tests/cypress/integration/actions_tasks3/case_105_cloud_storage.js
+++ b/tests/cypress/integration/actions_tasks3/case_105_cloud_storage.js
@@ -20,7 +20,9 @@ context('Cloud storage.', () => {
         manifest: 'manifest.jsonl',
         resource: 'container',
         display_name: 'Demonstration container',
-    }
+        prefix: 'GCS_prefix',
+        projectID: 'Some ID',
+    };
 
     before(() => {
         cy.visit('auth/login');
@@ -109,6 +111,40 @@ context('Cloud storage.', () => {
                 .click();
             cy.get('#account_name').should('exist');
             cy.get('#SAS_token').should('not.exist');
+        });
+
+        it('Check "Google cloud storage" provider fields.', () => {
+            cy.contains('.cvat-cloud-storage-select-provider', 'Azure').click();
+            cy.contains('.cvat-cloud-storage-select-provider', 'Google').click();
+            cy.get('#resource')
+                .should('exist')
+                .should('have.attr', 'value', dummyData.resource);
+            cy.get('#credentials_type').should('exist').click();
+            cy.get('.ant-select-dropdown')
+                .not('.ant-select-dropdown-hidden')
+                .get('[title="Key file"]')
+                .should('be.visible')
+                .click();
+            cy.get('.cvat-cloud-storage-form-item-key-file').should('be.visible');
+            cy.get('[title="Key file"]').first().click();
+            cy.get('.ant-select-dropdown')
+                .not('.ant-select-dropdown-hidden')
+                .get('[title="Anonymous access"]')
+                .should('be.visible')
+                .click();
+            cy.get('.cvat-cloud-storage-form-item-key-file').should('not.exist');
+            cy.get('#prefix').should('exist').type(dummyData.prefix).should('have.value', dummyData.prefix);
+            cy.get('#project_id').should('exist').type(dummyData.projectID).should('have.value', dummyData.projectID);
+            cy.get('#location').should('exist').click();
+            cy.get('.ant-select-dropdown')
+                .not('.ant-select-dropdown-hidden')
+                .get('.cvat-cloud-storage-region-creator')
+                .should('be.visible')
+                .within(() => {
+                    cy.contains('button', 'Add region').click();
+                });
+            cy.get('.cvat-incorrect-add-region-notification').should('exist');
+            cy.closeNotification('.cvat-incorrect-add-region-notification');
             cy.get('.cvat-cloud-storage-reset-button').click();
             cy.get('.cvat-cloud-storage-form').should('not.exist');
         });


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->
Related:
#3919 
#3959 

### Motivation and context
Adding a test to check "Google cloud storage" provider fields.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
