### PR TITLE
Cypress. Fix case 108 for Firefox.

### DIFF
--- a/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
+++ b/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
@@ -49,7 +49,6 @@ context('Rotated bounding boxes.', () => {
 
     function testCompareRotate(shape, toFrame) {
         for (let frame = 8; frame >= toFrame; frame--) {
-            cy.log(frame);
             cy.document().then((doc) => {
                 const shapeTranformMatrix = doc.getElementById(shape).getCTM();
                 cy.goToPreviousFrame(frame);

--- a/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
+++ b/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
@@ -83,8 +83,10 @@ context('Rotated bounding boxes.', () => {
                 const shapeTranformMatrix = doc.getElementById('cvat_canvas_shape_2').getCTM();
                 for (let frame = 1; frame < 10; frame++) {
                     cy.goToNextFrame(frame);
-                    const nextShapeTranformMatrix = doc.getElementById('cvat_canvas_shape_2').getCTM();
-                    expect(nextShapeTranformMatrix).to.deep.eq(shapeTranformMatrix);
+                    cy.document().then((docNext) => {
+                        const nextShapeTranformMatrix = docNext.getElementById('cvat_canvas_shape_2').getCTM();
+                        expect(nextShapeTranformMatrix).to.deep.eq(shapeTranformMatrix);
+                    });
                 }
             });
 

--- a/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
+++ b/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
@@ -49,10 +49,13 @@ context('Rotated bounding boxes.', () => {
 
     function testCompareRotate(shape, toFrame) {
         for (let frame = 8; frame >= toFrame; frame--) {
-            cy.get(shape).invoke('css', 'transform').then(($transform) => {
+            cy.log(frame);
+            cy.document().then((doc) => {
+                const shapeTranformMatrix = doc.getElementById(shape).getCTM();
                 cy.goToPreviousFrame(frame);
-                cy.get(shape).invoke('css', 'transform').then(($transform2) => {
-                    expect($transform).not.eq($transform2);
+                cy.document().then((doc2) => {
+                    const shapeTranformMatrix2 = doc2.getElementById(shape).getCTM();
+                    expect(shapeTranformMatrix).not.deep.eq(shapeTranformMatrix2);
                 });
             });
         }
@@ -77,19 +80,19 @@ context('Rotated bounding boxes.', () => {
 
         it('Check interpolation, merging/splitting rotated shapes.', () => {
             // Check track roration on all frames
-            cy.get('#cvat_canvas_shape_2').invoke('css', 'transform').then((shape2) => {
+            cy.document().then((doc) => {
+                const shapeTranformMatrix = doc.getElementById('cvat_canvas_shape_2').getCTM();
                 for (let frame = 1; frame < 10; frame++) {
                     cy.goToNextFrame(frame);
-                    cy.get('#cvat_canvas_shape_2').invoke('css', 'transform').then((shape2Next) => {
-                        expect(shape2).to.be.eq(shape2Next);
-                    });
+                    const nextShapeTranformMatrix = doc.getElementById('cvat_canvas_shape_2').getCTM();
+                    expect(nextShapeTranformMatrix).to.deep.eq(shapeTranformMatrix);
                 }
             });
 
             testShapeRotate('#cvat_canvas_shape_2', 350, 250, '91.9°');
 
             // Comparison of the values of the shape attribute of the current frame with the previous frame
-            testCompareRotate('#cvat_canvas_shape_2', 0);
+            testCompareRotate('cvat_canvas_shape_2', 0);
 
             // Merge shapes
             cy.goCheckFrameNumber(0);
@@ -112,7 +115,7 @@ context('Rotated bounding boxes.', () => {
             testShapeRotate('#cvat_canvas_shape_4', 350, 250, '18.5°');
 
             // Comparison of the values of the shape attribute of the current frame with the previous frame
-            testCompareRotate('#cvat_canvas_shape_4', 2);
+            testCompareRotate('cvat_canvas_shape_4', 2);
 
             cy.goCheckFrameNumber(3);
             // Split tracks


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Related #3961
I slightly reworked the test due to the fact that in Firefox the shape does not have the css ```transform``` property.
A solution of the form 
```
const shapeAttrs = shape2.attr('transform').split('(')[1].split(')')[0].split(',');
```
it looks ugly.
Found a solution using ```getCTM()```.
CI for check: https://github.com/dvkruchinin/cvat/runs/4394611968?check_suite_focus=true

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
