### PR TITLE
Cypress. Update case 60 for check fix "Autoborder points are visible for invisible shapes"

### DIFF
--- a/tests/cypress/integration/actions_objects/case_60_autoborder_feature.js
+++ b/tests/cypress/integration/actions_objects/case_60_autoborder_feature.js
@@ -28,6 +28,16 @@ context('Autoborder feature.', () => {
         secondY: 450,
     };
 
+    const createRectangleShape2PointsHidden = {
+        points: 'By 2 Points',
+        type: 'Shape',
+        labelName,
+        firstX: 200,
+        firstY: 350,
+        secondX: 300,
+        secondY: 450,
+    };
+
     const keyCodeN = 78;
     const rectangleSvgJsCircleId = [];
     const rectangleSvgJsCircleIdSecond = [];
@@ -66,6 +76,11 @@ context('Autoborder feature.', () => {
         cy.openTaskJob(taskName);
         cy.createRectangle(createRectangleShape2Points);
         cy.createRectangle(createRectangleShape2PointsSec);
+
+        // Check PR 3931 "Fixed issue: autoborder points are visible for invisible shapes"
+        cy.createRectangle(createRectangleShape2PointsHidden);
+        cy.get('#cvat-objects-sidebar-state-item-3').find('[data-icon="eye"]').click();
+        cy.get('#cvat_canvas_shape_3').should('be.hidden');
     });
 
     describe(`Testing case "${caseId}"`, () => {
@@ -86,7 +101,7 @@ context('Autoborder feature.', () => {
             cy.get('.cvat_canvas_autoborder_point').should('not.exist');
 
             // Collect the polygon points coordinates
-            testActivatingShape(450, 300, '#cvat_canvas_shape_3');
+            testActivatingShape(450, 300, '#cvat_canvas_shape_4');
             testCollectCxCircleCoord(polygonSvgJsCircleId);
         });
 
@@ -105,7 +120,7 @@ context('Autoborder feature.', () => {
             cy.get('.cvat_canvas_autoborder_point').should('not.exist');
 
             // Collect the polygon points coordinates
-            testActivatingShape(550, 350, '#cvat_canvas_shape_4');
+            testActivatingShape(550, 350, '#cvat_canvas_shape_5');
             testCollectCxCircleCoord(polylineSvgJsCircleId);
         });
 


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->
Related: #3931 

### Motivation and context
Adding a check for "Autoborder points are visible for invisible shapes"

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
