### PR TITLE
Cypress. Update case 97 for check "Fixed issue: rotation property is not dumped when backup a task"

### DIFF
--- a/tests/cypress/integration/actions_tasks2/case_97_export_import_task.js
+++ b/tests/cypress/integration/actions_tasks2/case_97_export_import_task.js
@@ -25,17 +25,34 @@ context('Export, import an annotation task.', { browser: '!firefox' }, () => {
     let taskId;
     let taskBackupArchiveFullName;
 
-    const createPointsShape = {
+    const createRectangleShape2Points = {
+        points: 'By 2 Points',
         type: 'Shape',
         labelName,
-        pointsMap: [
-            { x: 200, y: 200 },
-            { x: 250, y: 200 },
-            { x: 250, y: 250 },
-        ],
-        complete: true,
-        numberOfPoints: null,
+        firstX: 250,
+        firstY: 350,
+        secondX: 350,
+        secondY: 450,
     };
+
+    function testShapeRotate(onlyCheckTransform = false) {
+        if (!onlyCheckTransform) {
+            cy.get('#cvat_canvas_shape_1')
+                .should('be.visible')
+                .trigger('mousemove')
+                .trigger('mouseover')
+                .should('have.class', 'cvat_canvas_shape_activated');
+            cy.get('.svg_select_points_rot')
+                .should('be.visible')
+                .and('have.length', 1)
+                .trigger('mousemove')
+                .trigger('mouseover');
+            cy.get('.svg_select_points_rot').trigger('mousedown', { button: 0 });
+            cy.get('.cvat-canvas-container').trigger('mousemove', 350, 150);
+            cy.get('.cvat-canvas-container').trigger('mouseup');
+        }
+        cy.get('#cvat_canvas_shape_1').should('have.attr', 'transform');
+    }
 
     before(() => {
         cy.visit('auth/login');
@@ -49,7 +66,8 @@ context('Export, import an annotation task.', { browser: '!firefox' }, () => {
         });
         cy.addNewLabel(newLabelName);
         cy.openJob();
-        cy.createPoint(createPointsShape);
+        cy.createRectangle(createRectangleShape2Points);
+        testShapeRotate();
         cy.saveJob();
         cy.goToTaskList();
     });
@@ -91,8 +109,10 @@ context('Export, import an annotation task.', { browser: '!firefox' }, () => {
                 expect(labels.length).to.be.equal(2);
             });
             cy.openJob(0, false);
-            cy.get('#cvat_canvas_shape_1').should('exist');
             cy.get('#cvat-objects-sidebar-state-item-1').should('exist');
+
+            // Check fix 3932 "Rotation property is not dumped when backup a task"
+            testShapeRotate(true);
         });
     });
 });


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->
Related: #3932 

### Motivation and context
The test has been redesigned to test the functionality of preserving the rotation of the rectangle after importing the task.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
