### PR TITLE
Cypress. Update case_1. Added check label color.

### DIFF
--- a/tests/cypress/integration/actions_tasks3/case_1_create_delete_task_label_color.js
+++ b/tests/cypress/integration/actions_tasks3/case_1_create_delete_task_label_color.js
@@ -4,14 +4,14 @@
 
 /// <reference types="cypress" />
 
-context('Create and delete a annotation task', () => {
+context('Create and delete a annotation task. Color collision.', () => {
     const caseId = '1';
-    const labelName = `Case ${caseId}`;
-    const taskName = `New annotation task for ${labelName}`;
-    const attrName = `Attr for ${labelName}`;
+    const labelName = 'adaf';
+    const taskName = `New annotation task for Case ${caseId}`;
+    const attrName = `Attr for Case ${caseId}`;
     const textDefaultValue = 'Some default value for type Text';
     const imagesCount = 1;
-    const imageFileName = `image_${labelName.replace(' ', '_').toLowerCase()}`;
+    const imageFileName = 'image_case_1';
     const width = 800;
     const height = 800;
     const posX = 10;
@@ -21,6 +21,7 @@ context('Create and delete a annotation task', () => {
     const archivePath = `cypress/fixtures/${archiveName}`;
     const imagesFolder = `cypress/fixtures/${imageFileName}`;
     const directoryToArchive = imagesFolder;
+    const newLabelName = 'adia';
 
     before(() => {
         cy.visit('auth/login');
@@ -29,15 +30,27 @@ context('Create and delete a annotation task', () => {
         cy.createZipArchive(directoryToArchive, archivePath);
     });
 
-    describe(`Testing "${labelName}"`, () => {
-        it('Create a task', () => {
+    describe(`Testing "Case ${caseId}"`, () => {
+        it('Create a task.', () => {
             cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, archiveName);
         });
 
-        it('Delete the created task', () => {
+        it('Add a label. Check labels color.', () => {
+            cy.openTask(taskName);
+            cy.addNewLabel(newLabelName);
+            cy.get('.cvat-constructor-viewer-item').first().then((firstLabel) => {
+                cy.get('.cvat-constructor-viewer-item').last().then((secondLabel) => {
+                    expect(firstLabel.attr('style')).not.equal(secondLabel.attr('style'));
+                });
+            });
+        });
+
+        it('Delete the created task.', () => {
+            cy.goToTaskList();
             cy.deleteTask(taskName);
         });
-        it('Deleted task not exist', () => {
+
+        it('Deleted task not exist.', () => {
             cy.contains('strong', taskName)
                 .parents('.cvat-tasks-list-item')
                 .should('have.attr', 'style')


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

Related on #4007 

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Updating the test to check for label color collisions.
I wrote a small script to identify color collisions of labels with different names.
```python
from cvat.apps.dataset_manager.formats.utils import get_label_color
import itertools

label_color = {}
dublicates = {}

lst = [''.join(x) for x in itertools.product('abcdifg', repeat=4)]
for i in lst:
    label_color[i] = get_label_color(i, label_color.keys())

for key, value in label_color.items():
    dublicates.setdefault(value, set()).add(key)

dubl = [values for key, values in dublicates.items() if len(values) > 1]

print(dubl)
```
As a result , I got the names of the labels:
```adaf``` and ```adia```
Which had the same color before the fix ```rgb(50, 182, 148)```.
Based on these data, the test has been redesigned.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
