### PR TITLE
Cypress. Update case 108. Find better way for check a shape rotation.

### DIFF
--- a/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
+++ b/tests/cypress/integration/actions_objects2/case_108_rotated_bounding_boxes.js
@@ -27,36 +27,49 @@ context('Rotated bounding boxes.', () => {
         secondY: createRectangleShape2Points.secondY - 150,
     };
 
-    function testShapeRotate(shape, x, y, expectedRotate, pressShift) {
-        // FIXME: find a better way to check expected rotation
-        // you can not predict rotation degree based on mousemove coordinates
-        // because it depends on cypress viewport scale
+    function deltaTransformPoint(matrix, point) {
+        const dx = point.x * matrix.a + point.y * matrix.c;
+        const dy = point.x * matrix.b + point.y * matrix.d;
+        return { x: dx, y: dy };
+    }
+
+    function decomposeMatrix(matrix) {
+        const px = deltaTransformPoint(matrix, { x: 0, y: 1 });
+        const skewX = ((180 / Math.PI) * Math.atan2(px.y, px.x) - 90).toFixed(1);
+        return skewX;
+    }
+
+    function testShapeRotate(shape, x, y, expectedRotateDeg, pressShift) {
         cy.get(shape)
             .trigger('mousemove')
             .trigger('mouseover')
             .should('have.class', 'cvat_canvas_shape_activated');
-        cy.get('.svg_select_points_rot')
-            .should('be.visible')
-            .and('have.length', 1)
-            .trigger('mousemove')
-            .trigger('mouseover');
+        cy.get('.cvat-canvas-container')
+            .trigger('mousemove', x, y)
+            .trigger('mouseenter', x, y);
+        cy.get('.svg_select_points_rot').should('have.class', 'cvat_canvas_selected_point');
+        cy.get('.cvat-canvas-container').trigger('mousedown', x, y, { button: 0 });
         if (pressShift) {
             cy.get('body').type('{shift}', { release: false });
         }
-        cy.get('.svg_select_points_rot').trigger('mousedown', { button: 0 });
-        cy.get('.cvat-canvas-container').trigger('mousemove', x, y);
-        // cy.get('#cvat_canvas_text_content').should('contain.text', expectedRotate);
-        cy.get('.cvat-canvas-container').trigger('mouseup');
+        cy.get('.cvat-canvas-container').trigger('mousemove', x + 20, y);
         cy.get(shape).should('have.attr', 'transform');
+        cy.document().then((doc) => {
+            const modShapeIDString = shape.substring(1); // Remove "#" from the shape id string
+            const shapeTranformMatrix = decomposeMatrix(doc.getElementById(modShapeIDString).getCTM());
+            cy.get('#cvat_canvas_text_content').should('contain.text', `${shapeTranformMatrix}°`);
+            expect(`${expectedRotateDeg}°`).to.be.equal(`${shapeTranformMatrix}°`);
+        });
+        cy.get('.cvat-canvas-container').trigger('mouseup');
     }
 
     function testCompareRotate(shape, toFrame) {
         for (let frame = 8; frame >= toFrame; frame--) {
             cy.document().then((doc) => {
-                const shapeTranformMatrix = doc.getElementById(shape).getCTM();
+                const shapeTranformMatrix = decomposeMatrix(doc.getElementById(shape).getCTM());
                 cy.goToPreviousFrame(frame);
                 cy.document().then((doc2) => {
-                    const shapeTranformMatrix2 = doc2.getElementById(shape).getCTM();
+                    const shapeTranformMatrix2 = decomposeMatrix(doc2.getElementById(shape).getCTM());
                     expect(shapeTranformMatrix).not.deep.eq(shapeTranformMatrix2);
                 });
             });
@@ -76,24 +89,36 @@ context('Rotated bounding boxes.', () => {
 
     describe(`Testing case "${caseId}"`, () => {
         it('Check that bounding boxes can be rotated.', () => {
-            testShapeRotate('#cvat_canvas_shape_1', 350, 150, '11.4°');
-            testShapeRotate('#cvat_canvas_shape_2', 350, 150, '26.6°');
+            testShapeRotate(
+                '#cvat_canvas_shape_1',
+                (createRectangleShape2Points.firstX + createRectangleShape2Points.secondX) / 2,
+                createRectangleShape2Points.firstY + 20,
+                '33.7',
+            );
+            testShapeRotate(
+                '#cvat_canvas_shape_2',
+                (createRectangleTrack2Points.firstX + createRectangleTrack2Points.secondX) / 2,
+                createRectangleTrack2Points.firstY + 20,
+                '33.7',
+            );
         });
 
         it('Check interpolation, merging/splitting rotated shapes.', () => {
             // Check track roration on all frames
             cy.document().then((doc) => {
-                const shapeTranformMatrix = doc.getElementById('cvat_canvas_shape_2').getCTM();
+                const shapeTranformMatrix = decomposeMatrix(doc.getElementById('cvat_canvas_shape_2').getCTM());
                 for (let frame = 1; frame < 10; frame++) {
                     cy.goToNextFrame(frame);
                     cy.document().then((docNext) => {
-                        const nextShapeTranformMatrix = docNext.getElementById('cvat_canvas_shape_2').getCTM();
+                        const nextShapeTranformMatrix = (
+                            decomposeMatrix(docNext.getElementById('cvat_canvas_shape_2').getCTM())
+                        );
                         expect(nextShapeTranformMatrix).to.deep.eq(shapeTranformMatrix);
                     });
                 }
             });
 
-            testShapeRotate('#cvat_canvas_shape_2', 350, 250, '91.9°');
+            testShapeRotate('#cvat_canvas_shape_2', 320, 225, '53.0');
 
             // Comparison of the values of the shape attribute of the current frame with the previous frame
             testCompareRotate('cvat_canvas_shape_2', 0);
@@ -113,10 +138,17 @@ context('Rotated bounding boxes.', () => {
                 .within(() => {
                     cy.get('.cvat-object-item-button-keyframe').click();
                     cy.get('.cvat-object-item-button-keyframe-enabled').should('not.exist');
+                    cy.get('.cvat-object-item-button-keyframe').trigger('mouseout');
                 });
             cy.get('#cvat_canvas_shape_4').should('be.visible');
             cy.goCheckFrameNumber(9);
-            testShapeRotate('#cvat_canvas_shape_4', 350, 250, '18.5°');
+
+            testShapeRotate(
+                '#cvat_canvas_shape_4',
+                (createRectangleShape2Points.firstX + createRectangleShape2Points.secondX) / 2,
+                createRectangleShape2Points.firstY + 20,
+                '33.7',
+            );
 
             // Comparison of the values of the shape attribute of the current frame with the previous frame
             testCompareRotate('cvat_canvas_shape_4', 2);
@@ -126,15 +158,28 @@ context('Rotated bounding boxes.', () => {
             cy.get('.cvat-split-track-control').click();
             // A single click does not reproduce the split a track scenario in cypress test.
             cy.get('#cvat_canvas_shape_2').click().click();
-            cy.get('#cvat_canvas_shape_5').should('have.attr', 'transform').then((shapeTransform) => {
-                cy.get('#cvat_canvas_shape_6').should('have.attr', 'transform', shapeTransform);
+
+            // Disabling outside for checking deg rotate correctly
+            cy.get('#cvat-objects-sidebar-state-item-5').within(() => {
+                cy.get('.cvat-object-item-button-outside').click();
+                cy.get('.cvat-object-item-button-outside').trigger('mouseout');
+            });
+
+            cy.document().then((doc) => {
+                const shapeTranformMatrix = decomposeMatrix(doc.getElementById('cvat_canvas_shape_5').getCTM());
+                cy.document().then((docNext) => {
+                    const nextShapeTranformMatrix = (
+                        decomposeMatrix(docNext.getElementById('cvat_canvas_shape_6').getCTM())
+                    );
+                    expect(nextShapeTranformMatrix).to.deep.eq(shapeTranformMatrix);
+                });
             });
         });
 
         it('Check rotation with hold Shift button.', () => {
             cy.goCheckFrameNumber(0);
-            testShapeRotate('#cvat_canvas_shape_4', 350, 150, '15.0°', true);
-            testShapeRotate('#cvat_canvas_shape_4', 400, 150, '30.0°', true);
+            testShapeRotate('#cvat_canvas_shape_4', 320, 375, '60.0', true);
+            testShapeRotate('#cvat_canvas_shape_4', 325, 385, '75.0', true);
         });
     });
 });


### PR DESCRIPTION
<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Reworking the test for target branch. 
Reworking check for a shape rotation. Calculating and checking the angle of rotation of a shape based on data from ```getCTM()```.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
