### PR TITLE
BUG FIX: Fixed temp_file flush issue for cloud storage in cache.py

### DIFF
--- a/cvat/apps/engine/cache.py
+++ b/cvat/apps/engine/cache.py
@@ -90,6 +90,7 @@ class CacheInteraction:
                             source_path = temp_file.name
                             buf = cloud_storage_instance.download_fileobj(file_name)
                             temp_file.write(buf.getvalue())
+                            temp_file.flush()
                             checksum = item.get('checksum', None)
                             if not checksum:
                                 slogger.cloud_storage[db_cloud_storage.id].warning('A manifest file does not contain checksum for image {}'.format(item.get('name')))


### PR DESCRIPTION
Issue Summary: File downloaded from cloud storage is not flushed. In case of lot of files, for some files, changes don't reflect in the actual physical file. Actual file is later accessed by filename, which leads to read error.

Issue Error logs:

```
2022-01-05 09:54:14,992 DEBG 'runserver' stderr output:
[Wed Jan 05 09:54:14.992125 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868] [2022-01-05 09:54:14,991] ERROR cvat.server.task_12: cannot get requested data type: chunk, number: 0, quality: Quality.COMPRESSED
[Wed Jan 05 09:54:14.992147 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868] Traceback (most recent call last):
[Wed Jan 05 09:54:14.992152 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]   File "/home/django/cvat/apps/engine/cache.py", line 96, in prepare_chunk_buff
[Wed Jan 05 09:54:14.992156 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]     if checksum and not md5_hash(source_path) == checksum:
[Wed Jan 05 09:54:14.992159 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]   File "/home/django/cvat/apps/engine/utils.py", line 100, in md5_hash
[Wed Jan 05 09:54:14.992163 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]     frame = Image.open(frame, 'r')
[Wed Jan 05 09:54:14.992166 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]   File "/opt/venv/lib/python3.8/site-packages/PIL/Image.py", line 3023, in open
[Wed Jan 05 09:54:14.992186 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]     raise UnidentifiedImageError(
[Wed Jan 05 09:54:14.992189 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868] PIL.UnidentifiedImageError: cannot identify image file '/tmp/cvat_041w7vsimages#0089c635-ae5f-49d7-baa5-a4d75f0412ca.png'
[Wed Jan 05 09:54:14.992192 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]
[Wed Jan 05 09:54:14.992196 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868] During handling of the above exception, another exception occurred:
[Wed Jan 05 09:54:14.992199 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]

2022-01-05 09:54:14,992 DEBG 'runserver' stderr output:
[Wed Jan 05 09:54:14.992202 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868] Traceback (most recent call last):
[Wed Jan 05 09:54:14.992205 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]   File "/home/django/cvat/apps/engine/views.py", line 689, in data
[Wed Jan 05 09:54:14.992208 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]     buff, mime_type = frame_provider.get_chunk(data_id, data_quality)
[Wed Jan 05 09:54:14.992211 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]   File "/home/django/cvat/apps/engine/frame_provider.py", line 167, in get_chunk
[Wed Jan 05 09:54:14.992215 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]     return self._loaders[quality].get_chunk_path(chunk_number, quality, self._db_data)
[Wed Jan 05 09:54:14.992218 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]   File "/home/django/cvat/apps/engine/cache.py", line 32, in get_buff_mime
[Wed Jan 05 09:54:14.992221 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]     chunk, tag = self.prepare_chunk_buff(db_data, quality, chunk_number)
[Wed Jan 05 09:54:14.992224 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]   File "/home/django/cvat/apps/engine/cache.py", line 113, in prepare_chunk_buff
[Wed Jan 05 09:54:14.992227 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868]     raise Exception(msg)
[Wed Jan 05 09:54:14.992231 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868] Exception: cannot identify image file '/tmp/cvat_041w7vsimages#0089c635-ae5f-49d7-baa5-a4d75f0412ca.png'
[Wed Jan 05 09:54:14.992414 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868] ERROR - 2022-01-05 09:54:14,991 - views - cannot get requested data type: chunk, number: 0, quality: Quality.COMPRESSED
[Wed Jan 05 09:54:14.992425 2022] [wsgi:error] [pid 330:tid 139683931096832] [remote 172.20.0.2:56868] Traceback (most recent call last):
```

<!---
Copyright (C) 2020-2021 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
~~- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly~~
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
~~- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2021 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
