### PR TITLE
Fixed issue: Uncaught TypeError: this.el.node.getScreenCTM() is null …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Order in an annotation file(<https://github.com/openvinotoolkit/cvat/pull/4087>)
 - Fixed task data upload progressbar (<https://github.com/openvinotoolkit/cvat/pull/4134>)
 - Email in org invitations is case sensitive (<https://github.com/openvinotoolkit/cvat/pull/4153>)
+- Uncaught TypeError: this.el.node.getScreenCTM() is null in Firefox (<https://github.com/openvinotoolkit/cvat/pull/4175>)
 - Bug: canvas is busy when start playing, start resizing a shape and do not release the mouse cursor (<https://github.com/openvinotoolkit/cvat/pull/4151>)
 - Fixed tus upload error over https (<https://github.com/openvinotoolkit/cvat/pull/4154>)
 

--- a/cvat-canvas/package-lock.json
+++ b/cvat-canvas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cvat-canvas",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cvat-canvas",
-      "version": "2.12.1",
+      "version": "2.12.2",
       "license": "MIT",
       "dependencies": {
         "@types/polylabel": "^1.0.5",

--- a/cvat-canvas/package.json
+++ b/cvat-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-canvas",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "Part of Computer Vision Annotation Tool which presents its canvas library",
   "main": "src/canvas.ts",
   "scripts": {

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -2014,8 +2014,6 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 shapeSizeElement.rm();
                 shapeSizeElement = null;
             }
-            // disable internal resize events of SVG.js
-            window.dispatchEvent(new MouseEvent('mouseup'));
             this.mode = Mode.IDLE;
         };
 
@@ -2032,7 +2030,11 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 if (state.shapeType === 'rectangle') {
                     shapeSizeElement = displayShapeSize(this.adoptedContent, this.adoptedText);
                 }
-                (shape as any).on('remove.resize', resizeFinally);
+                (shape as any).on('remove.resize', () => {
+                    // disable internal resize events of SVG.js
+                    window.dispatchEvent(new MouseEvent('mouseup'));
+                    resizeFinally();
+                });
             })
             .on('resizing', (): void => {
                 resized = true;

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -1947,6 +1947,8 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     hideText();
                     (shape as any).on('remove.drag', (): void => {
                         this.mode = Mode.IDLE;
+                        // disable internal drag events of SVG.js
+                        window.dispatchEvent(new MouseEvent('mouseup'));
                     });
                 })
                 .on('dragend', (e: CustomEvent): void => {
@@ -2012,6 +2014,8 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 shapeSizeElement.rm();
                 shapeSizeElement = null;
             }
+            // disable internal resize events of SVG.js
+            window.dispatchEvent(new MouseEvent('mouseup'));
             this.mode = Mode.IDLE;
         };
 


### PR DESCRIPTION
…in Firefox

<!---
Copyright (C) 2020-2022 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Resolved #4173

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
