### PR TITLE
Added YOLOv5 serverless function for auto labeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added information about OpenVINO toolkit to login page (<https://github.com/openvinotoolkit/cvat/pull/4077>)
 - Support for working with ellipses (<https://github.com/openvinotoolkit/cvat/pull/4062>)
 - Add several flags to task creation CLI (<https://github.com/openvinotoolkit/cvat/pull/4119>)
-
+- Add YOLOv5 serverless function for automatic annotation (<https://github.com/openvinotoolkit/cvat/pull/4178>)
 ### Changed
 - Users don't have access to a task object anymore if they are assigneed only on some jobs of the task (<https://github.com/openvinotoolkit/cvat/pull/3788>)
 - Different resources (tasks, projects) are not visible anymore for all CVAT instance users by default (<https://github.com/openvinotoolkit/cvat/pull/3788>)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For more information about supported formats look at the
 | [Object reidentification](/serverless/openvino/omz/intel/person-reidentification-retail-300/nuclio)     | reid       | OpenVINO   | X   |     |
 | [Semantic segmentation for ADAS](/serverless/openvino/omz/intel/semantic-segmentation-adas-0001/nuclio) | detector   | OpenVINO   | X   |     |
 | [Text detection v4](/serverless/openvino/omz/intel/text-detection-0004/nuclio)                          | detector   | OpenVINO   | X   |     |
+| [YOLO v5](/serverless/pytorch/ultralytics/yolov5/nuclio)                                                | detector   | PyTorch    | X   |     |
 | [SiamMask](/serverless/pytorch/foolwood/siammask/nuclio)                                                | tracker    | PyTorch    | X   | X   |
 | [f-BRS](/serverless/pytorch/saic-vul/fbrs/nuclio)                                                       | interactor | PyTorch    | X   |     |
 | [HRNet](/serverless/pytorch/saic-vul/hrnet/nuclio)                                                      | interactor | PyTorch    |     | X   |

--- a/serverless/pytorch/ultralytics/yolov5/nuclio/function.yaml
+++ b/serverless/pytorch/ultralytics/yolov5/nuclio/function.yaml
@@ -1,0 +1,121 @@
+metadata:
+  name: ultralytics-yolov5
+  namespace: cvat
+  annotations:
+    name: YOLO v5
+    type: detector
+    framework: pytorch
+    spec: |
+      [
+        { "id": 0, "name": "person" },
+        { "id": 1, "name": "bicycle" },
+        { "id": 2, "name": "car" },
+        { "id": 3, "name": "motorbike" },
+        { "id": 4, "name": "aeroplane" },
+        { "id": 5, "name": "bus" },
+        { "id": 6, "name": "train" },
+        { "id": 7, "name": "truck" },
+        { "id": 8, "name": "boat" },
+        { "id": 9, "name": "traffic light" },
+        { "id": 10, "name": "fire hydrant" },
+        { "id": 11, "name": "stop sign" },
+        { "id": 12, "name": "parking meter" },
+        { "id": 13, "name": "bench" },
+        { "id": 14, "name": "bird" },
+        { "id": 15, "name": "cat" },
+        { "id": 16, "name": "dog" },
+        { "id": 17, "name": "horse" },
+        { "id": 18, "name": "sheep" },
+        { "id": 19, "name": "cow" },
+        { "id": 20, "name": "elephant" },
+        { "id": 21, "name": "bear" },
+        { "id": 22, "name": "zebra" },
+        { "id": 23, "name": "giraffe" },
+        { "id": 24, "name": "backpack" },
+        { "id": 25, "name": "umbrella" },
+        { "id": 26, "name": "handbag" },
+        { "id": 27, "name": "tie" },
+        { "id": 28, "name": "suitcase" },
+        { "id": 29, "name": "frisbee" },
+        { "id": 30, "name": "skis" },
+        { "id": 31, "name": "snowboard" },
+        { "id": 32, "name": "sports ball" },
+        { "id": 33, "name": "kite" },
+        { "id": 34, "name": "baseball bat" },
+        { "id": 35, "name": "baseball glove" },
+        { "id": 36, "name": "skateboard" },
+        { "id": 37, "name": "surfboard" },
+        { "id": 38, "name": "tennis racket" },
+        { "id": 39, "name": "bottle" },
+        { "id": 40, "name": "wine glass" },
+        { "id": 41, "name": "cup" },
+        { "id": 42, "name": "fork" },
+        { "id": 43, "name": "knife" },
+        { "id": 44, "name": "spoon" },
+        { "id": 45, "name": "bowl" },
+        { "id": 46, "name": "banana" },
+        { "id": 47, "name": "apple" },
+        { "id": 48, "name": "sandwich" },
+        { "id": 49, "name": "orange" },
+        { "id": 50, "name": "broccoli" },
+        { "id": 51, "name": "carrot" },
+        { "id": 52, "name": "hot dog" },
+        { "id": 53, "name": "pizza" },
+        { "id": 54, "name": "donut" },
+        { "id": 55, "name": "cake" },
+        { "id": 56, "name": "chair" },
+        { "id": 57, "name": "sofa" },
+        { "id": 58, "name": "pottedplant" },
+        { "id": 59, "name": "bed" },
+        { "id": 60, "name": "diningtable" },
+        { "id": 61, "name": "toilet" },
+        { "id": 62, "name": "tvmonitor" },
+        { "id": 63, "name": "laptop" },
+        { "id": 64, "name": "mouse" },
+        { "id": 65, "name": "remote" },
+        { "id": 66, "name": "keyboard" },
+        { "id": 67, "name": "cell phone" },
+        { "id": 68, "name": "microwave" },
+        { "id": 69, "name": "oven" },
+        { "id": 70, "name": "toaster" },
+        { "id": 71, "name": "sink" },
+        { "id": 72, "name": "refrigerator" },
+        { "id": 73, "name": "book" },
+        { "id": 74, "name": "clock" },
+        { "id": 75, "name": "vase" },
+        { "id": 76, "name": "scissors" },
+        { "id": 77, "name": "teddy bear" },
+        { "id": 78, "name": "hair drier" },
+        { "id": 79, "name": "toothbrush" }
+      ]
+
+spec:
+  description: YOLO v5 via pytorch hub
+  runtime: 'python:3.6'
+  handler: main:handler
+  eventTimeout: 30s
+  build:
+    image: cvat/ultralytics-yolov5
+    baseImage: ultralytics/yolov5:latest
+
+    directives:
+      preCopy:
+        - kind: USER
+          value: root
+        - kind: WORKDIR
+          value: /opt/nuclio
+
+  triggers:
+    myHttpTrigger:
+      maxWorkers: 2
+      kind: 'http'
+      workerAvailabilityTimeoutMilliseconds: 10000
+      attributes:
+        maxRequestBodySize: 33554432 # 32MB
+
+  platform:
+    attributes:
+      restartPolicy:
+        name: always
+        maximumRetryCount: 3
+      mountMode: volume

--- a/serverless/pytorch/ultralytics/yolov5/nuclio/main.py
+++ b/serverless/pytorch/ultralytics/yolov5/nuclio/main.py
@@ -1,0 +1,41 @@
+import json
+import base64
+from PIL import Image
+import io
+import yaml
+import torch
+
+def init_context(context):
+    context.logger.info("Init context...  0%")
+
+    # Read the DL model
+    model = torch.hub.load('ultralytics/yolov5', 'yolov5s')  # or yolov5m, yolov5l, yolov5x, custom
+    context.user_data.model = model
+
+    context.logger.info("Init context...100%")
+
+def handler(context, event):
+    context.logger.info("Run yolo-v5 model")
+    data = event.body
+    buf = io.BytesIO(base64.b64decode(data["image"]))
+    threshold = float(data.get("threshold", 0.5))
+    context.user_data.model.conf = threshold
+    image = Image.open(buf)
+    yolo_results_json = context.user_data.model(image).pandas().xyxy[0].to_dict(orient='records')
+
+    encoded_results = []
+    for result in yolo_results_json:
+        encoded_results.append({
+            'confidence': result['confidence'],
+            'label': result['name'],
+            'points': [
+                result['xmin'],
+                result['ymin'],
+                result['xmax'],
+                result['ymax']
+            ],
+            'type': 'rectangle'
+        })
+
+    return context.Response(body=json.dumps(encoded_results), headers={},
+        content_type='application/json', status_code=200)

--- a/serverless/pytorch/ultralytics/yolov5/nuclio/main.py
+++ b/serverless/pytorch/ultralytics/yolov5/nuclio/main.py
@@ -2,7 +2,6 @@ import json
 import base64
 from PIL import Image
 import io
-import yaml
 import torch
 
 def init_context(context):


### PR DESCRIPTION
<!---
Copyright (C) 2020-2022 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Integration of YOLOv5 as a serverless nuclio function that can be used for auto-labeling. Ultralytics has released YOLOv5 a while ago and it's one of the most used computer vision libraries and therefore it would make sense to support it in CVAT. The integration is quite simple into CVAT as Ultralytics maintains a Pytorch Hub model (https://github.com/ultralytics/yolov5/issues/36) and a docker image (https://hub.docker.com/r/ultralytics/yolov5).
Related issues from ultralytics repo: https://github.com/ultralytics/yolov5/issues/5427
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
Automatic annotation was run using YOLOv5 on a custom dataset.
The serverless function was deployed using 
```
nuctl deploy --project-name cvat \
  --path serverless/pytorch/ultralytics/yolov5/nuclio \
  --volume `pwd`/serverless/common:/opt/nuclio/common \
  --platform local
```
Then using the 'Automatic annotation' action the function was tested and the auto-generated labels were controlled to check that no coordinates misfit is happening.
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I submit my changes into the `develop` branch
- [ x] I have added a description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ x] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ x] I have added tests to cover my changes
- [ x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
