### PR TITLE
Cypress. Enabled check text with an ellipse rotation.

### DIFF
--- a/tests/cypress/integration/actions_objects2/case_115_ellipse_shape_track_label.js
+++ b/tests/cypress/integration/actions_objects2/case_115_ellipse_shape_track_label.js
@@ -78,8 +78,6 @@ context('Actions on ellipse.', () => {
                 (createEllipseTrackSwitchLabel.rightX + createEllipseTrackSwitchLabel.cx) / 2,
                 createEllipseTrackSwitchLabel.topY + 20,
                 '53.1',
-                false,
-                false,
             );
             testCompareRotate('cvat_canvas_shape_4', 0);
             // Rotation with shift
@@ -89,7 +87,6 @@ context('Actions on ellipse.', () => {
                 createEllipseTrackSwitchLabel.topY + 20,
                 '60.0',
                 true,
-                false,
             );
         });
     });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -802,7 +802,7 @@ Cypress.Commands.add('exportTask', ({
     cy.closeNotification('.cvat-notification-notice-export-task-start');
 });
 
-Cypress.Commands.add('shapeRotate', (shape, x, y, expectedRotateDeg, pressShift) => {
+Cypress.Commands.add('shapeRotate', (shape, x, y, expectedRotateDeg, pressShift = false) => {
     cy.get(shape)
         .trigger('mousemove')
         .trigger('mouseover')

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -802,8 +802,7 @@ Cypress.Commands.add('exportTask', ({
     cy.closeNotification('.cvat-notification-notice-export-task-start');
 });
 
-// FIXME: remove "checkText" after implementstion for ellipse
-Cypress.Commands.add('shapeRotate', (shape, x, y, expectedRotateDeg, pressShift, checkText = true) => {
+Cypress.Commands.add('shapeRotate', (shape, x, y, expectedRotateDeg, pressShift) => {
     cy.get(shape)
         .trigger('mousemove')
         .trigger('mouseover')
@@ -821,9 +820,7 @@ Cypress.Commands.add('shapeRotate', (shape, x, y, expectedRotateDeg, pressShift,
     cy.document().then((doc) => {
         const modShapeIDString = shape.substring(1); // Remove "#" from the shape id string
         const shapeTranformMatrix = decomposeMatrix(doc.getElementById(modShapeIDString).getCTM());
-        if (checkText) {
-            cy.get('#cvat_canvas_text_content').should('contain.text', `${shapeTranformMatrix}°`);
-        }
+        cy.get('#cvat_canvas_text_content').should('contain.text', `${shapeTranformMatrix}°`);
         expect(`${expectedRotateDeg}°`).to.be.equal(`${shapeTranformMatrix}°`);
     });
     cy.get('.cvat-canvas-container').trigger('mouseup');


### PR DESCRIPTION
<!---
Copyright (C) 2020-2022 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->
Related on #4229 

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Activation of the text occurrence check when the ellipse rotates.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
