### PR TITLE
Update documentation. Fix mistakes in CLI section

### DIFF
--- a/site/content/en/docs/manual/advanced/cli.md
+++ b/site/content/en/docs/manual/advanced/cli.md
@@ -189,14 +189,14 @@ by using the [label constructor](/docs/manual/basics/creating_an_annotation_task
 
 ### Export task
 
-- Export task with id 136 in the format `COCO 1.0` :
+- Export task with id 136 to file "task_136.tar":
   ```bash
-  cli.py export --format "COCO 1.0" 136
+  cli.py export 136 task_136.tar
   ```
 
 ### Import
 
-- Import task from file "task_backup.zip" :
+- Import task from file "task_backup.zip":
   ```bash
   cli.py import task_backup.zip
   ```

--- a/site/content/en/docs/manual/advanced/cli.md
+++ b/site/content/en/docs/manual/advanced/cli.md
@@ -179,6 +179,10 @@ by using the [label constructor](/docs/manual/basics/creating_an_annotation_task
   ```bash
   cli.py dump --format "CVAT for images 1.1" 103 output.xml
   ```
+- Dump annotation task with id 104, in the format `COCO 1.0` and save to the file "output.tar":
+  ```bash
+  cli.py dump --format "COCO 1.0" 104 output.tar
+  ```
 
 ### Upload annotation
 


### PR DESCRIPTION
<!---
Copyright (C) 2020-2022 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->
Resolve #4244 

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [x] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
