### PR TITLE
[WIP] allow to add URLs as remote source for task where they redirect to the actual resource location

### DIFF
--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -257,7 +257,7 @@ def _download_data(urls, upload_dir):
         job.meta['status'] = '{} is being downloaded..'.format(url)
         job.save_meta()
 
-        response = requests.get(url, stream=True)
+        response = requests.get(url, stream=True, allow_redirects=True)
         if response.status_code == 200:
             response.raw.decode_content = True
             with open(os.path.join(upload_dir, name), 'wb') as output_file:


### PR DESCRIPTION
<!---
Copyright (C) 2020-2022 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
When adding a remote source URL for a task and that URL makes a redirect (e.g first auths the user and then forwards it to where the resource is located), the file wont be downloaded and not imported. By allowing to follow redirects when trying to download the resource, this limitation is removed

### How has this been tested?
Ran it locally and tested it

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [X] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [X] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
