### PR TITLE
Revert Open3D to 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TDB
 
 ### Fixed
-- TDB
+- Revert Open3D to 0.11.2 to prevent depencency conflicts (<https://github.com/openvinotoolkit/cvat/pull/4639>)
 
 ### Security
 - TDB

--- a/cvat/requirements/base.txt
+++ b/cvat/requirements/base.txt
@@ -42,7 +42,7 @@ tensorflow==2.8.0 # Optional requirement of Datumaro. Use tensorflow-macos==2.8.
 # archives. Don't use as a python module because it has GPL license.
 patool==1.12
 diskcache==5.0.2
-open3d==0.14.1
+open3d==0.11.2
 boto3==1.17.61
 azure-storage-blob==12.8.1
 google-cloud-storage==1.42.0


### PR DESCRIPTION
### Motivation and context

This change fixes a dependency conflict that causes a very old version
of Jinja2 to be installed (see #4618). Open3D is only used for PCD
conversion, so this reverting to an older version is acceptable.

This is a temporary workaround. As a future update we'd like to get rid
of the Open3D dependency, since it pulls in a bunch of unnecessary
dependencies. Also, we'd like to make python dependency resolution more
robust by pinning all (recursive) dependencies to specific versions with
a tool like pip-tools or poetry.

Fixes #4618. 

### How has this been tested?

Not tested yet. Will rely on CI to test. 

### Checklist
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2022 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
